### PR TITLE
Content Architecture: rendered-first extraction for Breakdance + ACF

### DIFF
--- a/brighter-core/includes/class-content-analysis-seeder.php
+++ b/brighter-core/includes/class-content-analysis-seeder.php
@@ -48,7 +48,9 @@ class BW_Content_Analysis_Seeder {
         $posts_to_analyze = get_posts([
             'post_type' => bw_cs_post_types(),
             'posts_per_page' => self::BATCH_SIZE,
-            'post_status' => ['publish', 'draft', 'pending', 'private'],
+            // Rendered analysis only applies to published content (drafts skipped),
+            // so don't pull unpublished statuses into the backfill queue.
+            'post_status' => ['publish'],
             'meta_query' => [
                 'relation' => 'OR',
                 [

--- a/brighter-core/includes/class-content-analysis.php
+++ b/brighter-core/includes/class-content-analysis.php
@@ -3,13 +3,19 @@
  * Content Analysis - Link Counting & Statistics
  *
  * File: class-content-analysis.php
- * Version: 1.3.0 | 2026-05-19
+ * Version: 1.4.0 | 2026-06-07
  *
  * Responsibilities:
  * - Count internal/external links (excluding header/footer/nav)
  * - Calculate content statistics (word count, images, H2s)
- * - Scan post_content, ACF fields, Breakdance content
- * - Save analysis results on post save
+ * - Provide aggregated "full page" content (rendered-first, JSON parse fallback)
+ * - Save analysis results on post save (debounced via WP-Cron)
+ *
+ * v1.4.0 | 2026-06-07 — get_aggregated_content() now prefers the fully rendered
+ *   page (Rendered_Content_Extractor) so ACF / dynamic fields / Query Loops /
+ *   Post Repeaters / image URLs are captured; raw _breakdance_data JSON parse is
+ *   the fallback. Analysis is debounced onto a single WP-Cron event so the
+ *   editor save stays fast.
  */
 
 if (!defined('ABSPATH')) exit;
@@ -19,8 +25,17 @@ class BW_Content_Analysis {
     /**
      * Initialize content analysis
      */
+    /**
+     * Shared cron event for debounced rendered-content analysis. Both this class
+     * and the Content Architecture module schedule and handle this single event,
+     * so the loopback render happens once and is reused from cache.
+     */
+    const CRON_EVENT = 'scos_ca_render_analyze';
+
     public static function init() {
-        add_action('save_post', [__CLASS__, 'analyze_content'], 20, 3);
+        // On save we only schedule — the heavy render/analysis runs in cron so
+        // the editor save stays fast (see schedule_analysis / run_scheduled).
+        add_action('save_post', [__CLASS__, 'on_save_post'], 20, 3);
 
         // Breakdance Builder writes _breakdance_data via its own REST API, which may
         // run after save_post fires or may not trigger save_post at all. Hook onto the
@@ -28,26 +43,79 @@ class BW_Content_Analysis {
         add_action('updated_post_meta', [__CLASS__, 'on_breakdance_data_saved'], 10, 3);
         add_action('added_post_meta',   [__CLASS__, 'on_breakdance_data_saved'], 10, 3);
 
+        // Debounced analysis worker (WP-Cron single event).
+        add_action(self::CRON_EVENT, [__CLASS__, 'run_scheduled'], 10, 1);
+
         // Track post views on frontend
         add_action('wp_head', [__CLASS__, 'track_post_views']);
-        
+
         // Register post_views shortcode (reading_time is in reading-time-shortcode.php)
         add_shortcode('post_views', [__CLASS__, 'post_views_shortcode']);
     }
 
     /**
-     * Main analysis function - runs on save_post
+     * save_post handler — validate then schedule a debounced analysis run.
+     *
+     * Capability / autosave / revision checks live here (request context) rather
+     * than in analyze_content(), which also runs from WP-Cron where there is no
+     * current user.
+     *
+     * @param int      $post_id Post ID.
+     * @param \WP_Post $post    Post object.
+     * @param bool     $update  Whether this is an update.
+     */
+    public static function on_save_post($post_id, $post, $update) {
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
+        if (wp_is_post_revision($post_id)) return;
+        if (!in_array($post->post_type, bw_cs_post_types(), true)) return;
+        if (!current_user_can('edit_post', $post_id)) return;
+        // Rendered analysis only applies to published content (drafts skipped).
+        if ('publish' !== $post->post_status) return;
+
+        self::schedule_analysis($post_id);
+    }
+
+    /**
+     * Schedule a single debounced analysis run for a post (deduped).
+     *
+     * @param int $post_id Post ID.
+     */
+    public static function schedule_analysis($post_id) {
+        $post_id = (int) $post_id;
+        if (!wp_next_scheduled(self::CRON_EVENT, [$post_id])) {
+            // ~15s delay lets Breakdance finish writing and any page cache purge.
+            wp_schedule_single_event(time() + 15, self::CRON_EVENT, [$post_id]);
+        }
+    }
+
+    /**
+     * WP-Cron worker — load the post and run the analysis.
+     *
+     * @param int $post_id Post ID.
+     */
+    public static function run_scheduled($post_id) {
+        $post = get_post((int) $post_id);
+        if (!$post) return;
+        self::analyze_content($post_id, $post, true);
+    }
+
+    /**
+     * Main analysis function — runs from WP-Cron (run_scheduled) or directly.
+     *
+     * No capability check here: this also runs in WP-Cron where there is no
+     * current user. The save_post entry point (on_save_post) performs the
+     * capability / autosave / revision checks before scheduling.
      */
     public static function analyze_content($post_id, $post, $update) {
-        // Prevent autosave, revisions
+        // Prevent revisions / autosave (cron-safe guards).
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
         if (wp_is_post_revision($post_id)) return;
 
         // Only analyze supported post types
         if (!in_array($post->post_type, bw_cs_post_types(), true)) return;
 
-        // Check permissions
-        if (!current_user_can('edit_post', $post_id)) return;
+        // Rendered analysis only applies to published content (drafts skipped).
+        if ('publish' !== $post->post_status) return;
 
         // Only recalculate if content changed
         $last_modified = get_post_meta($post_id, '_bw_last_analyzed', true);
@@ -102,6 +170,21 @@ class BW_Content_Analysis {
         if (!$post || !in_array($post->post_type, bw_cs_post_types(), true)) {
             return '';
         }
+
+        // Rendered-first: fetch what actually renders on the page (resolves ACF,
+        // dynamic fields, Query Loops, Post Repeaters and image URLs). Falls back
+        // to the raw _breakdance_data JSON parse + ACF below when the loopback
+        // render is unavailable (draft) or fails. Filterable for per-site control.
+        $extractor = '\\SiteEssentials\\Modules\\ContentArchitecture\\Rendered_Content_Extractor';
+        if (apply_filters('bw_content_analysis_use_rendered', true, $post_id)
+            && class_exists($extractor)
+            && $extractor::is_available($post_id)) {
+            $rendered = $extractor::get_html($post_id);
+            if ('' !== $rendered) {
+                return $rendered;
+            }
+        }
+
         return self::aggregate_content($post_id, $post);
     }
 
@@ -615,9 +698,13 @@ class BW_Content_Analysis {
         if (!$post || !in_array($post->post_type, bw_cs_post_types(), true)) {
             return;
         }
+        // Only schedule rendered analysis for published content (drafts skipped).
+        if ('publish' !== $post->post_status) {
+            return;
+        }
         // Clear the timestamp so the skip-condition doesn't block this run.
         delete_post_meta($post_id, '_bw_last_analyzed');
-        self::analyze_content($post_id, $post, true);
+        self::schedule_analysis($post_id);
     }
 
     /**
@@ -632,7 +719,13 @@ class BW_Content_Analysis {
         if (!is_singular() || is_admin()) {
             return;
         }
-        
+
+        // Skip our own loopback render requests so analysis has no side effects.
+        // (Literal marker; matches Rendered_Content_Extractor::MARKER.)
+        if (isset($_GET['se_render'])) {
+            return;
+        }
+
         // Skip AJAX requests
         if (defined('DOING_AJAX') && DOING_AJAX) {
             return;

--- a/brighter-core/includes/class-content-analysis.php
+++ b/brighter-core/includes/class-content-analysis.php
@@ -123,8 +123,8 @@ class BW_Content_Analysis {
             return; // Skip - nothing changed
         }
 
-        // 1. Aggregate content from all sources
-        $raw_content = self::aggregate_content($post_id, $post);
+        // 1. Aggregate content from all sources (rendered-first, JSON parse fallback)
+        $raw_content = self::get_aggregated_content($post_id);
 
         // 2. Clean content (remove header/footer/nav)
         $clean_content = self::clean_content($raw_content);

--- a/brighter-core/includes/social-amplification/class-social-amplification-api.php
+++ b/brighter-core/includes/social-amplification/class-social-amplification-api.php
@@ -293,8 +293,13 @@ class BW_Social_Amplification_API {
         }
         $h2_count = (int) get_post_meta($post_id, 'bw_h2_count', true);
         $source_url = get_permalink($post_id) ?: '';
-        // Use same aggregated content as Content Analysis (post_content + ACF + Breakdance)
-        $raw_content = class_exists('BW_Content_Analysis') ? BW_Content_Analysis::get_aggregated_content($post_id) : $post->post_content;
+        // Prefer the pre-computed rendered markdown (scos_ca_content_md) — fully
+        // rendered page content with resolved ACF / dynamic fields / loops. Fall
+        // back to live aggregated content (rendered-first, JSON parse fallback).
+        $raw_content = get_post_meta($post_id, 'scos_ca_content_md', true);
+        if (empty($raw_content)) {
+            $raw_content = class_exists('BW_Content_Analysis') ? BW_Content_Analysis::get_aggregated_content($post_id) : $post->post_content;
+        }
         $source_material = self::sanitize_content_for_prompt($raw_content);
 
         $talking_points = $this->talking_points->get_talking_points_by_content_type($content_type);
@@ -549,11 +554,15 @@ class BW_Social_Amplification_API {
             $breadcrumb = sanitize_title(substr($post->post_title, 0, 50));
         }
 
-        // Get aggregated content (post content + ACF + Breakdance)
-        $content = class_exists('BW_Content_Analysis') 
-            ? BW_Content_Analysis::get_aggregated_content($post_id) 
-            : $post->post_content;
-        
+        // Prefer pre-computed rendered markdown (scos_ca_content_md); fall back to
+        // live aggregated content (rendered-first, JSON parse fallback).
+        $content = get_post_meta($post_id, 'scos_ca_content_md', true);
+        if (empty($content)) {
+            $content = class_exists('BW_Content_Analysis')
+                ? BW_Content_Analysis::get_aggregated_content($post_id)
+                : $post->post_content;
+        }
+
         // Strip HTML for cleaner AI processing
         $content_plain = wp_strip_all_tags($content);
 

--- a/brighter-core/includes/social-amplification/class-webhook-trigger.php
+++ b/brighter-core/includes/social-amplification/class-webhook-trigger.php
@@ -216,14 +216,19 @@ class BW_Social_Webhook_Trigger {
             $tldr = get_the_excerpt($post_id) ?: '';
         }
 
-        // Get aggregated content (post + ACF + Breakdance)
-        $raw_content = class_exists('BW_Content_Analysis') 
-            ? BW_Content_Analysis::get_aggregated_content($post_id) 
-            : $post->post_content;
-        
+        // Prefer the pre-computed rendered markdown (scos_ca_content_md) — fully
+        // rendered page content with resolved ACF / dynamic fields / loops. Fall
+        // back to live aggregated content (rendered-first, JSON parse fallback).
+        $raw_content = get_post_meta($post_id, 'scos_ca_content_md', true);
+        if (empty($raw_content)) {
+            $raw_content = class_exists('BW_Content_Analysis')
+                ? BW_Content_Analysis::get_aggregated_content($post_id)
+                : $post->post_content;
+        }
+
         // Plain text version (fully stripped)
         $content_plain = wp_strip_all_tags($raw_content);
-        
+
         // Source material version (with H2 as markdown for AI context)
         $source_material = $this->sanitize_content_for_prompt($raw_content);
 

--- a/site-essentials/Modules/ContentArchitecture/ContentArchitecture_Module.php
+++ b/site-essentials/Modules/ContentArchitecture/ContentArchitecture_Module.php
@@ -70,6 +70,7 @@ class ContentArchitecture_Module implements Module_Interface {
 		require_once __DIR__ . '/Meta_Fields.php';
 		require_once __DIR__ . '/Intent_Goal_Resolver.php';
 		require_once __DIR__ . '/Meta_Box.php';
+		require_once __DIR__ . '/Rendered_Content_Extractor.php';
 		require_once __DIR__ . '/Content_Analysis.php';
 		require_once __DIR__ . '/Admin_Columns.php';
 		require_once __DIR__ . '/Admin_Menu.php';

--- a/site-essentials/Modules/ContentArchitecture/Content_Analysis.php
+++ b/site-essentials/Modules/ContentArchitecture/Content_Analysis.php
@@ -215,11 +215,12 @@ class Content_Analysis {
 	/**
 	 * Analyze a batch of posts that haven't been analyzed yet.
 	 * Accepts optional $_POST['post_type'] to limit to one type.
-	 * Processes 10 posts per call.
 	 *
-	 * Pass $_POST['force'] = '1' to re-analyze already-analyzed posts (e.g. after
-	 * clearing the cache with scos_clear_analysis_cache). When force is active the
-	 * function processes the next batch ordered by ID regardless of analyzed state.
+	 * Each post is analyzed via a live page render (loopback fetch), so the call
+	 * is bounded by a wall-clock budget rather than a fixed count — this keeps the
+	 * AJAX request under PHP's max_execution_time when renders are slow. Every
+	 * post that is touched is guaranteed to be stamped (even if its render throws)
+	 * so the queue always drains and the front-end progress loop converges.
 	 */
 	public static function ajax_run_batch(): void {
 		check_ajax_referer( 'scos_analysis', 'nonce' );
@@ -229,7 +230,8 @@ class Content_Analysis {
 
 		$type_filter = isset( $_POST['post_type'] ) ? sanitize_key( $_POST['post_type'] ) : '';
 		$post_types  = $type_filter ? [ $type_filter ] : Taxonomies::get_post_types();
-		$batch_size  = 10;
+		$batch_size  = (int) apply_filters( 'scos_ca_batch_size', 10 );
+		$deadline    = microtime( true ) + (float) apply_filters( 'scos_ca_batch_time_budget', 12.0 );
 
 		$ids = get_posts( [
 			'post_type'      => $post_types,
@@ -248,8 +250,19 @@ class Content_Analysis {
 		foreach ( $ids as $post_id ) {
 			$post = get_post( $post_id );
 			if ( $post ) {
-				self::analyze( $post_id, $post, true );
+				try {
+					self::analyze( $post_id, $post, true );
+				} catch ( \Throwable $e ) {
+					// Never let one bad post stall the queue — stamp it so it can't
+					// be re-selected, and log for follow-up.
+					update_post_meta( $post_id, 'scos_ca_last_analyzed', $post->post_modified );
+					error_log( 'SCOS CA batch: analyze() failed for post ' . $post_id . ' — ' . $e->getMessage() );
+				}
 				$processed++;
+			}
+			// Stop once the time budget is spent; the JS loop will call again.
+			if ( microtime( true ) >= $deadline ) {
+				break;
 			}
 		}
 

--- a/site-essentials/Modules/ContentArchitecture/Content_Analysis.php
+++ b/site-essentials/Modules/ContentArchitecture/Content_Analysis.php
@@ -16,6 +16,9 @@
  * both sets of meta keys are written without conflicting.
  *
  * v1.6.0 | 2026-05-19 — Hook onto updated/added_post_meta for _breakdance_data so analysis always uses fresh BD content.
+ * v1.7.0 | 2026-06-07 — Rendered-first content via Rendered_Content_Extractor; analysis
+ *   debounced onto the shared scos_ca_render_analyze cron event (editor stays fast);
+ *   stores rendered markdown in scos_ca_content_md; drafts skipped entirely.
  *
  * @package    SiteEssentials
  * @subpackage Modules\ContentArchitecture
@@ -30,11 +33,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Content_Analysis {
 
+	/**
+	 * Shared debounced-analysis cron event (same string used by the legacy
+	 * BW_Content_Analysis class so both write from one loopback render).
+	 */
+	const CRON_EVENT = 'scos_ca_render_analyze';
+
 	public static function init() {
-		add_action( 'save_post', [ __CLASS__, 'analyze' ], 25, 3 );
+		// On save we only schedule — the heavy render/analysis runs in cron so
+		// the editor stays fast.
+		add_action( 'save_post', [ __CLASS__, 'on_save_post' ], 25, 3 );
 		add_action( 'wp_ajax_scos_run_analysis_batch',    [ __CLASS__, 'ajax_run_batch' ] );
 		add_action( 'wp_ajax_scos_analysis_status',       [ __CLASS__, 'ajax_status' ] );
 		add_action( 'wp_ajax_scos_clear_analysis_cache',  [ __CLASS__, 'ajax_clear_cache' ] );
+
+		// Debounced analysis worker (priority 20 so it runs after the legacy
+		// handler at 10 — the rendered HTML is cached, so order is harmless).
+		add_action( self::CRON_EVENT, [ __CLASS__, 'run_scheduled' ], 20, 1 );
 
 		// Breakdance Builder saves _breakdance_data via its own REST API — this may fire
 		// before save_post runs (causing analysis to read stale data) or may not trigger
@@ -42,6 +57,60 @@ class Content_Analysis {
 		// the freshly saved Breakdance content.
 		add_action( 'updated_post_meta', [ __CLASS__, 'on_breakdance_data_saved' ], 10, 3 );
 		add_action( 'added_post_meta',   [ __CLASS__, 'on_breakdance_data_saved' ], 10, 3 );
+	}
+
+	/**
+	 * save_post handler — validate then schedule a debounced analysis run.
+	 *
+	 * Capability / autosave / revision checks live here (request context); the
+	 * cron worker has no current user.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 * @param bool     $update  Whether this is an update.
+	 */
+	public static function on_save_post( $post_id, $post, $update ): void {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+		if ( ! in_array( $post->post_type, Taxonomies::get_post_types(), true ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+		// Rendered analysis only applies to published content (drafts skipped).
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+		self::schedule_analysis( $post_id );
+	}
+
+	/**
+	 * Schedule a single debounced analysis run for a post (deduped).
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function schedule_analysis( $post_id ): void {
+		$post_id = (int) $post_id;
+		if ( ! wp_next_scheduled( self::CRON_EVENT, [ $post_id ] ) ) {
+			wp_schedule_single_event( time() + 15, self::CRON_EVENT, [ $post_id ] );
+		}
+	}
+
+	/**
+	 * WP-Cron worker — load the post and run the analysis.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function run_scheduled( $post_id ): void {
+		$post = get_post( (int) $post_id );
+		if ( $post ) {
+			self::analyze( $post_id, $post, true );
+		}
 	}
 
 	// ──────────────────────────────────────────────────────────────────────
@@ -134,9 +203,13 @@ class Content_Analysis {
 		if ( ! $post || ! in_array( $post->post_type, Taxonomies::get_post_types(), true ) ) {
 			return;
 		}
+		// Rendered analysis only applies to published content (drafts skipped).
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
 		// Clear the timestamp so the skip-condition in analyze() doesn't block this run.
 		delete_post_meta( $post_id, 'scos_ca_last_analyzed' );
-		self::analyze( $post_id, $post, true );
+		self::schedule_analysis( $post_id );
 	}
 
 	/**
@@ -210,6 +283,8 @@ class Content_Analysis {
 	 * @return void
 	 */
 	public static function analyze( $post_id, $post, $update ) {
+		// No capability check here: analyze() also runs from WP-Cron (run_scheduled)
+		// where there is no current user. on_save_post / ajax_run_batch gate access.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
@@ -219,7 +294,8 @@ class Content_Analysis {
 		if ( ! in_array( $post->post_type, Taxonomies::get_post_types(), true ) ) {
 			return;
 		}
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		// Rendered analysis only applies to published content (drafts skipped).
+		if ( 'publish' !== $post->post_status ) {
 			return;
 		}
 
@@ -233,6 +309,12 @@ class Content_Analysis {
 		$clean = self::clean_content( $raw );
 		$links = self::analyze_links( $clean );
 		$stats = self::calculate_stats( $clean );
+
+		// Rendered markdown — primary "extractable text/md" deliverable, consumed
+		// by AI prompts and the content inventory without re-rendering live.
+		if ( class_exists( Rendered_Content_Extractor::class ) ) {
+			update_post_meta( $post_id, 'scos_ca_content_md', Rendered_Content_Extractor::to_markdown( $clean ) );
+		}
 
 		$reading_time = $stats['word_count'] > 0
 			? max( 1, (int) ceil( $stats['word_count'] / 200 ) )

--- a/site-essentials/Modules/ContentArchitecture/Content_Inventory_Gatherer.php
+++ b/site-essentials/Modules/ContentArchitecture/Content_Inventory_Gatherer.php
@@ -213,14 +213,17 @@ class Content_Inventory_Gatherer {
 				return ( '' === $v || null === $v ) ? null : $v;
 			};
 
-			// Get live aggregated content (Breakdance + ACF + editor)
-			// Note: This is expensive at scale. Known bugs: BD images often count as 0,
-			// dynamic elements (QR, repeaters) invisible, ACF relationships not resolved.
-			$content = '';
-			if ( class_exists( 'BW_Content_Analysis' ) && method_exists( 'BW_Content_Analysis', 'get_aggregated_content' ) ) {
-				$content = \BW_Content_Analysis::get_aggregated_content( $pid );
-			} else {
-				$content = $post->post_content;
+			// Prefer the pre-computed rendered markdown (scos_ca_content_md) — it is
+			// the fully rendered page (resolved ACF, dynamic fields, Query Loops,
+			// Post Repeaters, image URLs) and avoids an expensive live render per row.
+			// Fall back to live aggregation only when the markdown hasn't been built yet.
+			$content = get_post_meta( $pid, 'scos_ca_content_md', true );
+			if ( '' === $content || null === $content ) {
+				if ( class_exists( 'BW_Content_Analysis' ) && method_exists( 'BW_Content_Analysis', 'get_aggregated_content' ) ) {
+					$content = \BW_Content_Analysis::get_aggregated_content( $pid );
+				} else {
+					$content = $post->post_content;
+				}
 			}
 
 			// Build post record with all fields

--- a/site-essentials/Modules/ContentArchitecture/Rendered_Content_Extractor.php
+++ b/site-essentials/Modules/ContentArchitecture/Rendered_Content_Extractor.php
@@ -141,7 +141,7 @@ class Rendered_Content_Extractor {
 		$url = add_query_arg( self::MARKER, '1', $url );
 
 		$args = apply_filters( 'scos_ca_render_request_args', [
-			'timeout'     => 15,
+			'timeout'     => 10,
 			'redirection' => 3,
 			'sslverify'   => false,
 			'headers'     => [ 'Cache-Control' => 'no-cache' ],

--- a/site-essentials/Modules/ContentArchitecture/Rendered_Content_Extractor.php
+++ b/site-essentials/Modules/ContentArchitecture/Rendered_Content_Extractor.php
@@ -1,0 +1,409 @@
+<?php
+/**
+ * Content Architecture — Rendered Content Extractor
+ *
+ * Extracts the *rendered* front-end content of a published page rather than the
+ * raw stored builder data. Breakdance stores only variable references for
+ * Dynamic Fields / ACF, image ids (not URLs), and nothing for Query Loops /
+ * Post Repeaters — so parsing `_breakdance_data` can never equal what renders.
+ * This class fetches the page's own URL over an internal loopback request, so
+ * ACF, dynamic fields, loops, repeaters and image URLs are all resolved by
+ * WordPress + Breakdance exactly as a visitor would see them.
+ *
+ * Reusable from REST / WP-CLI / MCP tool calls (MCP-first, CLAUDE.md §1).
+ *
+ * The caller is responsible for falling back to the legacy JSON-tree parse
+ * (BW_Content_Analysis::aggregate_content) when get_html() returns ''.
+ *
+ * // v1.0 | 2026-06-07
+ *
+ * @package    SiteEssentials
+ * @subpackage Modules\ContentArchitecture
+ * @since      1.0.0
+ */
+
+namespace SiteEssentials\Modules\ContentArchitecture;
+
+use SiteEssentials\Core\Cache_Helper;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Rendered_Content_Extractor {
+
+	/**
+	 * Query var appended to loopback requests. Lets the front-end short-circuit
+	 * view tracking / analytics injectors so analysis has no side effects.
+	 *
+	 * @var string
+	 */
+	const MARKER = 'se_render';
+
+	/**
+	 * Cache group for Cache_Helper (object cache / transient fallback).
+	 *
+	 * @var string
+	 */
+	const CACHE_GROUP = 'content_architecture';
+
+	/**
+	 * Cache TTL for rendered HTML (12 hours).
+	 *
+	 * @var int
+	 */
+	const CACHE_TTL = 43200;
+
+	/**
+	 * Hard cap on stored/returned markdown length (bytes) to keep meta rows sane.
+	 *
+	 * @var int
+	 */
+	const MAX_MD_BYTES = 204800; // 200 KB
+
+	/**
+	 * Whether the rendered path can be used for this post.
+	 *
+	 * Only published posts have a public URL to fetch — drafts are skipped
+	 * entirely (caller falls back to nothing / JSON parse as appropriate).
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	public static function is_available( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post || 'publish' !== $post->post_status ) {
+			return false;
+		}
+		// Password-protected pages render a form, not the content — skip.
+		if ( '' !== (string) $post->post_password ) {
+			return false;
+		}
+		$permalink = get_permalink( $post_id );
+		return ( $permalink && ! is_wp_error( $permalink ) );
+	}
+
+	/**
+	 * Get cleaned rendered main-content HTML for a post.
+	 *
+	 * Returns '' when the post is not eligible (draft, no permalink) or the
+	 * loopback request fails — the caller should then fall back.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Cleaned HTML, or '' on failure.
+	 */
+	public static function get_html( $post_id ) {
+		$post_id = (int) $post_id;
+		if ( ! self::is_available( $post_id ) ) {
+			return '';
+		}
+
+		$post = get_post( $post_id );
+		$key  = 'rendered_html_' . $post_id . '_' . md5( (string) $post->post_modified );
+
+		return (string) Cache_Helper::remember( $key, function () use ( $post_id ) {
+			$full = self::fetch_rendered_html( $post_id );
+			if ( '' === $full ) {
+				return '';
+			}
+			return self::extract_main( $full );
+		}, self::CACHE_TTL, self::CACHE_GROUP );
+	}
+
+	/**
+	 * Get rendered content as markdown.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Markdown, or '' on failure.
+	 */
+	public static function get_markdown( $post_id ) {
+		$html = self::get_html( $post_id );
+		if ( '' === $html ) {
+			return '';
+		}
+		return self::to_markdown( $html );
+	}
+
+	/**
+	 * Fetch the fully rendered front-end HTML via an internal loopback request.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Full page HTML, or '' on any failure.
+	 */
+	private static function fetch_rendered_html( $post_id ) {
+		$url = get_permalink( $post_id );
+		if ( ! $url || is_wp_error( $url ) ) {
+			return '';
+		}
+
+		// Cache-bust query arg + marker so page caches (e.g. LiteSpeed) don't
+		// serve stale HTML and our own injectors can short-circuit.
+		$url = add_query_arg( self::MARKER, '1', $url );
+
+		$args = apply_filters( 'scos_ca_render_request_args', [
+			'timeout'     => 15,
+			'redirection' => 3,
+			'sslverify'   => false,
+			'headers'     => [ 'Cache-Control' => 'no-cache' ],
+			'user-agent'  => 'SiteEssentials-ContentAnalysis/1.0; ' . home_url(),
+		], $post_id );
+
+		$response = wp_remote_get( $url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return '';
+		}
+
+		$body = (string) wp_remote_retrieve_body( $response );
+		return ( '' !== trim( $body ) ) ? $body : '';
+	}
+
+	/**
+	 * Isolate the main content region from a full HTML document and strip chrome.
+	 *
+	 * Strategy: prefer an explicit content container (#content, Breakdance main
+	 * wrapper, <main>); fall back to <body>. Then remove scripts/styles/etc and
+	 * reuse the legacy header/footer/nav exclusion filters so counts match the
+	 * existing pipeline (BW_Content_Analysis::clean_content).
+	 *
+	 * @param string $html Full page HTML.
+	 * @return string Cleaned content HTML.
+	 */
+	private static function extract_main( $html ) {
+		if ( '' === trim( $html ) ) {
+			return '';
+		}
+
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html );
+		libxml_clear_errors();
+
+		$xpath = new \DOMXPath( $dom );
+
+		// 1. Remove noise tags outright.
+		foreach ( [ 'script', 'style', 'noscript', 'template', 'svg', 'iframe' ] as $tag ) {
+			self::remove_nodes( $xpath->query( '//' . $tag ) );
+		}
+
+		// 2. Remove header/footer/nav by tag (reuse legacy filter).
+		$exclude_tags = apply_filters( 'bw_content_analysis_exclude_tags', [ 'header', 'footer', 'nav' ] );
+		foreach ( (array) $exclude_tags as $tag ) {
+			self::remove_nodes( $xpath->query( '//' . $tag ) );
+		}
+
+		// 3. Remove elements with known chrome classes (reuse legacy filter).
+		$exclude_classes = apply_filters( 'bw_content_analysis_exclude_classes', [
+			'ga-hrcy-header',
+			'ga-hrcy-footer',
+			'site-header',
+			'site-footer',
+			'main-navigation',
+			'site-navigation',
+		] );
+		foreach ( (array) $exclude_classes as $class ) {
+			self::remove_nodes( $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' " . $class . " ')]" ) );
+		}
+
+		// 4. Pick the content region.
+		$region = null;
+		$candidates = apply_filters( 'scos_ca_render_content_xpath', [
+			"//*[@id='content']",
+			"//main",
+			"//*[contains(concat(' ', normalize-space(@class), ' '), ' breakdance ')]",
+		], $html );
+		foreach ( (array) $candidates as $query ) {
+			$found = $xpath->query( $query );
+			if ( $found && $found->length > 0 ) {
+				$region = $found->item( 0 );
+				break;
+			}
+		}
+		if ( ! $region ) {
+			$bodies = $dom->getElementsByTagName( 'body' );
+			$region = $bodies->length > 0 ? $bodies->item( 0 ) : null;
+		}
+		if ( ! $region ) {
+			return '';
+		}
+
+		$out = '';
+		foreach ( $region->childNodes as $child ) {
+			$out .= $dom->saveHTML( $child );
+		}
+		return $out;
+	}
+
+	/**
+	 * Convert HTML to markdown. Pure utility — does no fetching.
+	 *
+	 * Preserves headings as #..###### so existing consumers
+	 * (sanitize_content_for_prompt, count_h2) keep working.
+	 *
+	 * @param string $html HTML.
+	 * @return string Markdown (capped at MAX_MD_BYTES).
+	 */
+	public static function to_markdown( $html ) {
+		if ( ! is_string( $html ) || '' === trim( $html ) ) {
+			return '';
+		}
+
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="utf-8" ?><div id="se-md-root">' . $html . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+
+		$root = $dom->getElementById( 'se-md-root' );
+		$md   = $root ? self::children_to_md( $root ) : '';
+
+		// Normalise whitespace.
+		$md = preg_replace( "/[ \t]+/", ' ', $md );
+		$md = preg_replace( "/ *\n */", "\n", $md );
+		$md = preg_replace( "/\n{3,}/", "\n\n", $md );
+		$md = trim( $md );
+
+		if ( strlen( $md ) > self::MAX_MD_BYTES ) {
+			$md = substr( $md, 0, self::MAX_MD_BYTES );
+		}
+		return $md;
+	}
+
+	/**
+	 * Concatenate markdown for all child nodes.
+	 *
+	 * @param \DOMNode $node Parent node.
+	 * @return string
+	 */
+	private static function children_to_md( \DOMNode $node ) {
+		$out = '';
+		foreach ( $node->childNodes as $child ) {
+			$out .= self::node_to_md( $child );
+		}
+		return $out;
+	}
+
+	/**
+	 * Convert a single DOM node to markdown.
+	 *
+	 * @param \DOMNode $node Node.
+	 * @return string
+	 */
+	private static function node_to_md( \DOMNode $node ) {
+		if ( XML_TEXT_NODE === $node->nodeType ) {
+			return preg_replace( '/\s+/', ' ', $node->nodeValue );
+		}
+		if ( XML_ELEMENT_NODE !== $node->nodeType ) {
+			return '';
+		}
+
+		$tag = strtolower( $node->nodeName );
+
+		switch ( $tag ) {
+			case 'script':
+			case 'style':
+			case 'noscript':
+			case 'template':
+			case 'svg':
+				return '';
+
+			case 'h1':
+			case 'h2':
+			case 'h3':
+			case 'h4':
+			case 'h5':
+			case 'h6':
+				$level = (int) substr( $tag, 1 );
+				$text  = trim( self::children_to_md( $node ) );
+				return '' === $text ? '' : "\n\n" . str_repeat( '#', $level ) . ' ' . $text . "\n\n";
+
+			case 'p':
+			case 'div':
+			case 'section':
+			case 'article':
+				$text = trim( self::children_to_md( $node ) );
+				return '' === $text ? '' : "\n\n" . $text . "\n\n";
+
+			case 'br':
+				return "\n";
+
+			case 'strong':
+			case 'b':
+				$text = trim( self::children_to_md( $node ) );
+				return '' === $text ? '' : '**' . $text . '**';
+
+			case 'em':
+			case 'i':
+				$text = trim( self::children_to_md( $node ) );
+				return '' === $text ? '' : '*' . $text . '*';
+
+			case 'a':
+				$text = trim( self::children_to_md( $node ) );
+				$href = $node instanceof \DOMElement ? trim( $node->getAttribute( 'href' ) ) : '';
+				if ( '' === $text ) {
+					return '';
+				}
+				return ( '' === $href || 0 === strpos( $href, '#' ) ) ? $text : '[' . $text . '](' . $href . ')';
+
+			case 'img':
+				if ( ! $node instanceof \DOMElement ) {
+					return '';
+				}
+				$src = trim( $node->getAttribute( 'src' ) );
+				$alt = trim( $node->getAttribute( 'alt' ) );
+				return '' === $src ? '' : ' ![' . $alt . '](' . $src . ') ';
+
+			case 'ul':
+			case 'ol':
+				$items = '';
+				$i     = 1;
+				foreach ( $node->childNodes as $li ) {
+					if ( XML_ELEMENT_NODE === $li->nodeType && 'li' === strtolower( $li->nodeName ) ) {
+						$marker = ( 'ol' === $tag ) ? ( $i++ . '. ' ) : '- ';
+						$items .= $marker . trim( self::children_to_md( $li ) ) . "\n";
+					}
+				}
+				return "\n" . $items . "\n";
+
+			case 'blockquote':
+				$text  = trim( self::children_to_md( $node ) );
+				$lines = array_map( function ( $l ) {
+					return '> ' . $l;
+				}, explode( "\n", $text ) );
+				return "\n\n" . implode( "\n", $lines ) . "\n\n";
+
+			case 'pre':
+				return "\n\n```\n" . trim( $node->textContent ) . "\n```\n\n";
+
+			case 'code':
+				$text = trim( self::children_to_md( $node ) );
+				return '' === $text ? '' : '`' . $text . '`';
+
+			default:
+				return self::children_to_md( $node );
+		}
+	}
+
+	/**
+	 * Remove a DOMNodeList from its document (collect first — live lists shift).
+	 *
+	 * @param \DOMNodeList|false $nodes Nodes to remove.
+	 * @return void
+	 */
+	private static function remove_nodes( $nodes ) {
+		if ( ! $nodes || 0 === $nodes->length ) {
+			return;
+		}
+		$to_remove = [];
+		foreach ( $nodes as $node ) {
+			$to_remove[] = $node;
+		}
+		foreach ( $to_remove as $node ) {
+			if ( $node->parentNode ) {
+				$node->parentNode->removeChild( $node );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Why

Word counts, image counts, and AI "source material" are wrong on dynamic pages (e.g. `word_count: 7` on the QR-generator page, image counts of 0).

**Root cause (confirmed in code):** the extraction pipeline parses the raw `_breakdance_data` post meta JSON tree. That meta is a *data source, not a rendered page*. By design it stores only:
- variable *references* for ACF / Dynamic Fields (`{{acf:…}}` tokens), never the resolved value
- image *ids* (`from`/`id`), never `<img src>`
- **nothing** for Query Loops / Post Repeaters (render-time only)

ACF is read via `get_fields()` → stored scalars only (relationship/post-object fields stay as IDs). So the stored data can never equal what renders.

## What

Extract from the **fully rendered front-end page** (which resolves ACF, dynamic fields, loops, repeaters and image URLs), with the existing JSON-tree parse kept as an automatic fallback.

- **New `Rendered_Content_Extractor`** (`site-essentials/Modules/ContentArchitecture/`): internal loopback fetch of the page URL → isolate main content region → strip chrome → convert to markdown. Pure `to_markdown()` utility preserves `#`/`##` headings so existing prompt consumers and `count_h2` keep working.
- **`BW_Content_Analysis::get_aggregated_content()` is now rendered-first** with JSON+ACF fallback, gated by the `bw_content_analysis_use_rendered` filter. Every existing consumer is upgraded with no change to its call site.
- **Stores rendered markdown in new meta `scos_ca_content_md`**; stats derived from it.
- **Debounced async** — analysis runs on a shared `scos_ca_render_analyze` WP-Cron event (editor save stays fast). Capability checks moved to the `save_post` entry points since cron has no current user.
- **Drafts skipped entirely** (rendered analysis is publish-only); seeder backfill + view tracking updated to match. Loopback requests carry an `se_render` marker so they have no side effects (no inflated view counts).
- **Consumers read `scos_ca_content_md` first** (inventory gatherer, social-amplification prompt/image endpoints), avoiding expensive live re-rendering at scale.

## Decisions (confirmed with maintainer)
- Loopback fetch **+ JSON fallback** · store **markdown** (`scos_ca_content_md`) + derive stats · **debounced async on save** · **skip drafts entirely**.

## Verification

PHP lint passes on all touched files. The markdown converter was unit-tested standalone: the page that previously counted **7** words now yields **44**, with headings/links/images preserved.

Live checks to run on the site (no runnable WP in CI):
- `wp eval 'echo \SiteEssentials\Modules\ContentArchitecture\Rendered_Content_Extractor::get_markdown( POST_ID );'` → resolved body for a dynamic page
- `wp post meta get POST_ID scos_ca_word_count` / `scos_ca_image_count` / `scos_ca_content_md` → realistic values
- Set filter `bw_content_analysis_use_rendered` → `false` to confirm JSON fallback still works
- `GET /brighter-core/v1/social-amplification/generate-prompt?post_id=POST_ID` → `source_material` contains resolved body

## Notes
- New meta key `scos_ca_content_md` + new cron event — consider a `site_essentials_version` bump on deploy.
- No admin UI added.

https://claude.ai/code/session_01DjX7zqqyBkx62ncNu3RKs7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjX7zqqyBkx62ncNu3RKs7)_