### PR TITLE
Add RevisionViewer module — front-end revision browser for editors/admins

### DIFF
--- a/site-essentials.php
+++ b/site-essentials.php
@@ -174,6 +174,11 @@ add_action('init', function() {
             \SiteEssentials\Modules\SiteSchema\SiteSchema_Module::class
         );
 
+        \SiteEssentials\Core\Module_Loader::register(
+            'revision_viewer',
+            \SiteEssentials\Modules\RevisionViewer\RevisionViewer_Module::class
+        );
+
         // CRITICAL: Disable WordPress core sitemaps (wp-sitemap.xml) so only our sitemap.xml is used.
         // WP core registers at init priority 5; we must run earlier. Use priority 0 so we run first.
         add_action('init', function() {

--- a/site-essentials/Modules/ContentArchitecture/Meta_Fields.php
+++ b/site-essentials/Modules/ContentArchitecture/Meta_Fields.php
@@ -15,6 +15,7 @@
  * @since      1.0.0
  *
  * v1.1 | 2026-05-22 — Added scos_ca_intent_goal_faq_id integer meta key.
+ * v1.2 | 2026-06-10 — Added "review" to next_step_options(); triggers Revision Viewer.
  */
 
 namespace SiteEssentials\Modules\ContentArchitecture;
@@ -316,6 +317,8 @@ class Meta_Fields {
 	/**
 	 * Next step options (single-select colour badge).
 	 *
+	 * "revise" and "review" also activate the front-end Revision Viewer module.
+	 *
 	 * @return array<string, array{label: string, color: string, bg: string}>
 	 */
 	public static function next_step_options() {
@@ -324,6 +327,7 @@ class Meta_Fields {
 			'approve' => [ 'label' => 'Approved',    'color' => '#15803d', 'bg' => '#dcfce7' ],
 			'testing' => [ 'label' => 'Testing',     'color' => '#ca8a04', 'bg' => '#fef9c3' ],
 			'revise'  => [ 'label' => 'Revise',      'color' => '#2563eb', 'bg' => '#dbeafe' ],
+			'review'  => [ 'label' => 'Review',      'color' => '#0d9488', 'bg' => '#ccfbf1' ],
 			'merge'   => [ 'label' => 'Merge',       'color' => '#7c3aed', 'bg' => '#ede9fe' ],
 			'archive' => [ 'label' => 'Archive',     'color' => '#dc2626', 'bg' => '#fee2e2' ],
 		];

--- a/site-essentials/Modules/RevisionViewer/RevisionViewer_Module.php
+++ b/site-essentials/Modules/RevisionViewer/RevisionViewer_Module.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Revision Viewer Module
+ *
+ * Front-end revision browser for editors and admins.
+ * Activates on posts/pages whose scos_ca_next_step is "revise" or "review".
+ * Zero additional meta keys — reads directly from WordPress core revisions.
+ *
+ * @package    SiteEssentials
+ * @subpackage Modules\RevisionViewer
+ * @since      1.0.0
+ *
+ * v1.0 | 2026-06-10
+ */
+
+namespace SiteEssentials\Modules\RevisionViewer;
+
+use SiteEssentials\Core\Module_Interface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RevisionViewer_Module implements Module_Interface {
+
+	public static function get_id() {
+		return 'revision_viewer';
+	}
+
+	public static function get_name() {
+		return __( 'Revision Viewer', 'site-essentials' );
+	}
+
+	public static function get_description() {
+		return __( 'Browse rendered front-end revisions via a floating panel. Activates only on posts/pages with workflow status set to Revise or Review.', 'site-essentials' );
+	}
+
+	public static function get_tier() {
+		return 'pro';
+	}
+
+	public static function get_dependencies() {
+		return [ 'content_architecture' ];
+	}
+
+	public static function get_version() {
+		return '1.0.0';
+	}
+
+	public function init() {
+		require_once __DIR__ . '/Revision_Viewer.php';
+		Revision_Viewer::init();
+	}
+
+	public function render_settings() {
+		// No configurable settings — activation is driven entirely by scos_ca_next_step.
+		echo '<p class="description">' . esc_html__( 'Revision Viewer is active. It appears automatically on any post or page whose Content Architecture workflow status is set to Revise or Review.', 'site-essentials' ) . '</p>';
+	}
+}

--- a/site-essentials/Modules/RevisionViewer/Revision_Viewer.php
+++ b/site-essentials/Modules/RevisionViewer/Revision_Viewer.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Revision Viewer — Core Logic
+ *
+ * Injects a floating revision navigation panel on the front end for
+ * editors/admins. Swaps page content with a specific revision when
+ * ?view_revision=ID appears in the URL.
+ *
+ * Activation: post/page must have scos_ca_next_step = "revise" or "review".
+ * Access: users with edit_pages or edit_posts capability only.
+ * Security: revision ownership verified against current post before loading.
+ *
+ * @package    SiteEssentials
+ * @subpackage Modules\RevisionViewer
+ * @since      1.0.0
+ *
+ * v1.0 | 2026-06-10
+ */
+
+namespace SiteEssentials\Modules\RevisionViewer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Revision_Viewer {
+
+	/** Workflow statuses that enable the front-end revision viewer. */
+	const ACTIVE_STATUSES = [ 'revise', 'review' ];
+
+	/** @var int|null Revision ID being previewed; null means live. */
+	private static $active_revision_id = null;
+
+	/** @var \WP_Post|null The revision being previewed. */
+	private static $active_revision = null;
+
+	public static function init() {
+		add_filter( 'query_vars',         [ self::class, 'add_query_vars' ] );
+		add_action( 'wp',                 [ self::class, 'maybe_load_revision' ] );
+		add_filter( 'the_content',        [ self::class, 'maybe_swap_content' ], 1 );
+		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_assets' ] );
+		add_action( 'wp_footer',          [ self::class, 'render_panel' ] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Hooks
+	// -------------------------------------------------------------------------
+
+	public static function add_query_vars( $vars ) {
+		$vars[] = 'view_revision';
+		return $vars;
+	}
+
+	/**
+	 * At the wp hook: load and validate the requested revision.
+	 */
+	public static function maybe_load_revision() {
+		if ( ! is_singular() || ! self::can_access() ) {
+			return;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! self::is_enabled_for_post( $post_id ) ) {
+			return;
+		}
+
+		$revision_id = absint( get_query_var( 'view_revision', 0 ) );
+		if ( ! $revision_id ) {
+			return;
+		}
+
+		$revision = wp_get_post_revision( $revision_id );
+
+		// Verify the revision belongs to this post — prevents viewing arbitrary revisions.
+		if ( ! $revision || (int) $revision->post_parent !== $post_id ) {
+			return;
+		}
+
+		self::$active_revision_id = $revision_id;
+		self::$active_revision    = $revision;
+	}
+
+	/**
+	 * Swap live post content with the active revision's content.
+	 *
+	 * Runs at priority 1 so it fires before block parsing (priority 9).
+	 * Temporarily removes itself before re-applying the full filter chain
+	 * on the revision content to avoid infinite recursion.
+	 *
+	 * @param string $content
+	 * @return string
+	 */
+	public static function maybe_swap_content( $content ) {
+		if ( ! is_singular() || ! in_the_loop() || ! is_main_query() ) {
+			return $content;
+		}
+
+		if ( null === self::$active_revision ) {
+			return $content;
+		}
+
+		// Remove self, process revision through full filter chain (blocks, shortcodes, etc.), re-add.
+		remove_filter( 'the_content', [ self::class, 'maybe_swap_content' ], 1 );
+		$processed = apply_filters( 'the_content', self::$active_revision->post_content );
+		add_filter( 'the_content', [ self::class, 'maybe_swap_content' ], 1 );
+
+		return $processed;
+	}
+
+	/**
+	 * Enqueue the panel CSS only on eligible singular pages for eligible users.
+	 */
+	public static function enqueue_assets() {
+		if ( ! is_singular() || ! self::can_access() ) {
+			return;
+		}
+
+		if ( ! self::is_enabled_for_post( get_the_ID() ) ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'scos-revision-viewer',
+			SITE_ESSENTIALS_URL . 'Modules/RevisionViewer/assets/css/revision-viewer.css',
+			[],
+			'1.0.0'
+		);
+	}
+
+	/**
+	 * Output the floating revision panel in the footer.
+	 */
+	public static function render_panel() {
+		if ( ! is_singular() || ! self::can_access() ) {
+			return;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! self::is_enabled_for_post( $post_id ) ) {
+			return;
+		}
+
+		$revisions = self::get_revisions( $post_id );
+		if ( empty( $revisions ) ) {
+			return;
+		}
+
+		$current_id = self::$active_revision_id;
+		$live_url   = get_permalink( $post_id );
+		$next_step  = get_post_meta( $post_id, 'scos_ca_next_step', true );
+
+		// Build a sequential (0-indexed) list, newest-first.
+		$rev_list  = array_values( $revisions );
+		$rev_count = count( $rev_list );
+
+		$newer_url      = null;
+		$older_url      = null;
+		$pos_label      = 'Live version';
+		$viewing_date   = null;
+		$viewing_author = null;
+
+		if ( null !== $current_id ) {
+			// Find this revision in the list.
+			$cur_idx = null;
+			foreach ( $rev_list as $i => $rev ) {
+				if ( (int) $rev->ID === $current_id ) {
+					$cur_idx = $i;
+					break;
+				}
+			}
+
+			if ( null !== $cur_idx ) {
+				$current_rev    = $rev_list[ $cur_idx ];
+				$pos_label      = sprintf(
+					/* translators: 1: revision number, 2: total revisions */
+					__( 'Revision %1$d of %2$d', 'site-essentials' ),
+					$cur_idx + 1,
+					$rev_count
+				);
+				$viewing_date   = date_i18n( 'j M Y, g:i a', strtotime( $current_rev->post_date ) );
+				$viewing_author = get_the_author_meta( 'display_name', $current_rev->post_author );
+
+				// Newer = lower index (toward live). At index 0, newer = live.
+				$newer_url = $cur_idx > 0
+					? add_query_arg( 'view_revision', $rev_list[ $cur_idx - 1 ]->ID, $live_url )
+					: $live_url;
+
+				// Older = higher index (away from live).
+				$older_url = $cur_idx < $rev_count - 1
+					? add_query_arg( 'view_revision', $rev_list[ $cur_idx + 1 ]->ID, $live_url )
+					: null;
+			}
+		} else {
+			// On live version — can navigate into revisions (oldest from here = revision 1).
+			$older_url = add_query_arg( 'view_revision', $rev_list[0]->ID, $live_url );
+		}
+
+		$is_viewing_revision = null !== $current_id;
+
+		include __DIR__ . '/views/panel.php';
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private static function can_access() {
+		return is_user_logged_in() &&
+		       ( current_user_can( 'edit_pages' ) || current_user_can( 'edit_posts' ) );
+	}
+
+	private static function is_enabled_for_post( $post_id ) {
+		$status = get_post_meta( $post_id, 'scos_ca_next_step', true );
+		return in_array( $status, self::ACTIVE_STATUSES, true );
+	}
+
+	/**
+	 * Return non-autosave revisions for a post, newest-first.
+	 *
+	 * @param int $post_id
+	 * @return \WP_Post[]
+	 */
+	private static function get_revisions( $post_id ) {
+		$revisions = wp_get_post_revisions( $post_id, [
+			'order'   => 'DESC',
+			'orderby' => 'date ID',
+		] );
+
+		return array_filter( $revisions, function( $rev ) {
+			return ! wp_is_post_autosave( $rev );
+		} );
+	}
+}

--- a/site-essentials/Modules/RevisionViewer/assets/css/revision-viewer.css
+++ b/site-essentials/Modules/RevisionViewer/assets/css/revision-viewer.css
@@ -1,0 +1,191 @@
+/**
+ * SCOS Revision Viewer — Front-End Panel Styles
+ *
+ * Fixed mid-right panel, visible only to editors/admins.
+ * Namespaced with scos-rv- to avoid conflicts with any theme.
+ *
+ * v1.0 | 2026-06-10
+ */
+
+/* ── Panel container ───────────────────────────────────────────── */
+
+.scos-rv-panel {
+	position: fixed;
+	right: 0;
+	top: 50%;
+	transform: translateY(-50%);
+	z-index: 999990;
+	width: 220px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	font-size: 13px;
+	line-height: 1.4;
+	color: #1f2937;
+	filter: drop-shadow(-3px 0 12px rgba(0, 0, 0, 0.15));
+}
+
+.scos-rv-panel details {
+	background: #ffffff;
+	border: 1px solid #e5e7eb;
+	border-right: none;
+	border-radius: 10px 0 0 10px;
+	overflow: hidden;
+}
+
+/* ── Header (summary) ──────────────────────────────────────────── */
+
+.scos-rv-panel__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 10px 14px;
+	background: #4f46e5;
+	cursor: pointer;
+	user-select: none;
+	list-style: none;
+}
+
+/* Remove default browser disclosure triangle */
+.scos-rv-panel__header::-webkit-details-marker { display: none; }
+.scos-rv-panel__header::marker { display: none; }
+
+.scos-rv-panel__title {
+	font-weight: 600;
+	font-size: 12px;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: #ffffff;
+}
+
+/* ── Status badge ──────────────────────────────────────────────── */
+
+.scos-rv-panel__badge {
+	font-size: 10px;
+	font-weight: 600;
+	padding: 2px 7px;
+	border-radius: 999px;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	white-space: nowrap;
+}
+
+.scos-rv-badge--revise {
+	background: #dbeafe;
+	color: #1d4ed8;
+}
+
+.scos-rv-badge--review {
+	background: #ccfbf1;
+	color: #0d9488;
+}
+
+/* ── Panel body ────────────────────────────────────────────────── */
+
+.scos-rv-panel__body {
+	padding: 12px 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.scos-rv-panel__state {
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+.scos-rv-panel__state strong {
+	font-size: 13px;
+	color: #111827;
+}
+
+.scos-rv-panel__meta {
+	font-size: 11px;
+	color: #6b7280;
+	line-height: 1.3;
+}
+
+/* ── Navigation row ────────────────────────────────────────────── */
+
+.scos-rv-panel__nav {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.scos-rv-btn {
+	display: inline-block;
+	padding: 4px 8px;
+	font-size: 11px;
+	font-weight: 500;
+	border-radius: 5px;
+	text-decoration: none;
+	white-space: nowrap;
+	cursor: pointer;
+	transition: background 0.12s ease;
+	background: #f3f4f6;
+	color: #374151;
+	border: 1px solid #e5e7eb;
+	flex: 1;
+	text-align: center;
+}
+
+.scos-rv-btn:hover {
+	background: #e5e7eb;
+	color: #111827;
+	text-decoration: none;
+}
+
+.scos-rv-btn--live {
+	background: #4f46e5;
+	color: #ffffff;
+	border-color: #4338ca;
+}
+
+.scos-rv-btn--live:hover {
+	background: #4338ca;
+	color: #ffffff;
+}
+
+.scos-rv-btn--active {
+	background: #e0e7ff;
+	color: #3730a3;
+	border-color: #c7d2fe;
+	cursor: default;
+}
+
+.scos-rv-btn--disabled {
+	background: #f9fafb;
+	color: #d1d5db;
+	border-color: #f3f4f6;
+	cursor: not-allowed;
+	pointer-events: none;
+}
+
+/* ── Collapsed state ───────────────────────────────────────────── */
+
+/* When collapsed, only the header is visible — keep it usable */
+.scos-rv-panel details:not([open]) .scos-rv-panel__header {
+	border-radius: 10px 0 0 10px;
+}
+
+/* Add a subtle arrow indicator */
+.scos-rv-panel__header::after {
+	content: "▲";
+	font-size: 9px;
+	color: rgba(255, 255, 255, 0.7);
+	transition: transform 0.2s ease;
+}
+
+.scos-rv-panel details:not([open]) .scos-rv-panel__header::after {
+	content: "▼";
+}
+
+/* ── Responsive: don't overlap on small viewports ──────────────── */
+
+@media (max-width: 480px) {
+	.scos-rv-panel {
+		width: 180px;
+	}
+}

--- a/site-essentials/Modules/RevisionViewer/views/panel.php
+++ b/site-essentials/Modules/RevisionViewer/views/panel.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Revision Viewer — Floating Front-End Panel
+ *
+ * Variables injected by Revision_Viewer::render_panel():
+ *   int|null  $current_id            — active revision ID, null = live
+ *   string    $live_url              — clean permalink (no query args)
+ *   string    $next_step             — scos_ca_next_step value
+ *   array     $rev_list              — WP_Post[] revisions, newest-first
+ *   int       $rev_count             — total revision count
+ *   string|null $newer_url           — URL for the newer step (null = disabled)
+ *   string|null $older_url           — URL for the older step (null = disabled)
+ *   string    $pos_label             — "Live version" | "Revision N of M"
+ *   string|null $viewing_date        — formatted date of active revision
+ *   string|null $viewing_author      — display name of revision author
+ *   bool      $is_viewing_revision   — true when previewing a revision
+ *
+ * @package SiteEssentials\Modules\RevisionViewer
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$status_labels = [
+	'revise' => __( 'Revise',  'site-essentials' ),
+	'review' => __( 'Review',  'site-essentials' ),
+];
+$status_label = isset( $status_labels[ $next_step ] ) ? $status_labels[ $next_step ] : esc_html( ucfirst( $next_step ) );
+?>
+<aside id="scos-rv-panel" class="scos-rv-panel scos-rv-panel--<?php echo esc_attr( $next_step ); ?>" aria-label="<?php esc_attr_e( 'Revision viewer', 'site-essentials' ); ?>">
+	<details open>
+		<summary class="scos-rv-panel__header">
+			<span class="scos-rv-panel__title"><?php esc_html_e( 'Revisions', 'site-essentials' ); ?></span>
+			<span class="scos-rv-panel__badge scos-rv-badge--<?php echo esc_attr( $next_step ); ?>"><?php echo esc_html( $status_label ); ?></span>
+		</summary>
+
+		<div class="scos-rv-panel__body">
+
+			<p class="scos-rv-panel__state">
+				<?php if ( $is_viewing_revision ) : ?>
+					<strong><?php echo esc_html( $pos_label ); ?></strong>
+					<?php if ( $viewing_date ) : ?>
+						<span class="scos-rv-panel__meta"><?php echo esc_html( $viewing_date ); ?></span>
+					<?php endif; ?>
+					<?php if ( $viewing_author ) : ?>
+						<span class="scos-rv-panel__meta"><?php printf( esc_html__( 'by %s', 'site-essentials' ), esc_html( $viewing_author ) ); ?></span>
+					<?php endif; ?>
+				<?php else : ?>
+					<strong><?php esc_html_e( 'Live version', 'site-essentials' ); ?></strong>
+					<span class="scos-rv-panel__meta">
+						<?php printf(
+							/* translators: %d: number of revisions */
+							esc_html( _n( '%d revision available', '%d revisions available', $rev_count, 'site-essentials' ) ),
+							$rev_count
+						); ?>
+					</span>
+				<?php endif; ?>
+			</p>
+
+			<nav class="scos-rv-panel__nav" aria-label="<?php esc_attr_e( 'Revision navigation', 'site-essentials' ); ?>">
+
+				<?php if ( $newer_url ) : ?>
+					<a href="<?php echo esc_url( $newer_url ); ?>"
+					   class="scos-rv-btn"
+					   title="<?php esc_attr_e( 'View newer revision', 'site-essentials' ); ?>">
+						&#8592; <?php esc_html_e( 'Newer', 'site-essentials' ); ?>
+					</a>
+				<?php else : ?>
+					<span class="scos-rv-btn scos-rv-btn--disabled" aria-disabled="true">&#8592; <?php esc_html_e( 'Newer', 'site-essentials' ); ?></span>
+				<?php endif; ?>
+
+				<?php if ( $is_viewing_revision ) : ?>
+					<a href="<?php echo esc_url( $live_url ); ?>" class="scos-rv-btn scos-rv-btn--live"><?php esc_html_e( 'Live', 'site-essentials' ); ?></a>
+				<?php else : ?>
+					<span class="scos-rv-btn scos-rv-btn--live scos-rv-btn--active" aria-current="true"><?php esc_html_e( 'Live', 'site-essentials' ); ?></span>
+				<?php endif; ?>
+
+				<?php if ( $older_url ) : ?>
+					<a href="<?php echo esc_url( $older_url ); ?>"
+					   class="scos-rv-btn"
+					   title="<?php esc_attr_e( 'View older revision', 'site-essentials' ); ?>">
+						<?php esc_html_e( 'Older', 'site-essentials' ); ?> &#8594;
+					</a>
+				<?php else : ?>
+					<span class="scos-rv-btn scos-rv-btn--disabled" aria-disabled="true"><?php esc_html_e( 'Older', 'site-essentials' ); ?> &#8594;</span>
+				<?php endif; ?>
+
+			</nav>
+
+		</div>
+	</details>
+</aside>


### PR DESCRIPTION
## Summary

- **New `RevisionViewer` module** — a floating, fixed mid-right panel that lets editors and admins browse rendered front-end revisions using `← Newer / Live / Older →` navigation
- **Zero new meta keys** — reads directly from WordPress core revisions; no DB bloat
- **Activation is workflow-driven** — the panel only appears when `scos_ca_next_step` is `revise` or `review` (per-post, no sitewide setting needed)
- **New `review` status added** to CA `next_step_options()` — teal badge, sits between `revise` and `testing` to complete the revise → review → approve workflow

## How it works

1. Editor sets a post/page's CA workflow status to **Revise** or **Review**
2. When an editor/admin visits the front end of that page, a collapsible panel appears fixed to the right edge at screen midpoint
3. Clicking **Older →** loads the most recent revision (URL: `?view_revision=123`); the panel swaps the page content with the revision content server-side
4. **← Newer / Older →** navigate through the revision list; **Live** always returns to the published version
5. The panel shows: revision N of M, date, author of the revision being viewed
6. Autosaves are excluded from the revision list

## Security

- `current_user_can('edit_pages')` or `edit_posts` checked before any output
- Revision ownership verified against the current post ID — arbitrary `?view_revision=` values are rejected
- Panel CSS only enqueued on eligible singular pages for eligible users

## Files changed

| File | Change |
|---|---|
| `Modules/RevisionViewer/RevisionViewer_Module.php` | New module class |
| `Modules/RevisionViewer/Revision_Viewer.php` | Core logic (hooks, content swap, panel render) |
| `Modules/RevisionViewer/views/panel.php` | Floating panel HTML template |
| `Modules/RevisionViewer/assets/css/revision-viewer.css` | Panel styles |
| `Modules/ContentArchitecture/Meta_Fields.php` | Add `review` to `next_step_options()` |
| `site-essentials.php` | Register `revision_viewer` module |

## Test plan

- [ ] Set a post's `scos_ca_next_step` to **Revise** or **Review** in the editor
- [ ] Visit the post as an admin/editor on the front end — panel should appear mid-right
- [ ] Click **Older →** — page content should update to the most recent revision
- [ ] Navigate with **← Newer** and **Older →** through all revisions
- [ ] Click **Live** — should return to the published version with no query param
- [ ] Visit the page as a logged-out user — panel must NOT appear
- [ ] Set `scos_ca_next_step` to **Approved** — panel must NOT appear
- [ ] Attempt `?view_revision=` with an ID from a different post — should silently load live version
- [ ] Collapse the panel via the `<details>` toggle — only the header should remain visible

https://claude.ai/code/session_015cJHeXYwetdzJbwzspjUyd

---
_Generated by [Claude Code](https://claude.ai/code/session_015cJHeXYwetdzJbwzspjUyd)_