### PR TITLE
feat: connect bw_reviews to projects without ACF (native meta + connected BDE mode)

### DIFF
--- a/site-essentials/Modules/CustomPosts/Cpt_Module.php
+++ b/site-essentials/Modules/CustomPosts/Cpt_Module.php
@@ -733,6 +733,17 @@ JS;
         $customer_detail = get_post_meta($post->ID, 'bw_customer_detail', true);
         $is_featured     = get_post_meta($post->ID, 'bw_is_featured', true);
         $review_excerpt  = get_post_meta($post->ID, 'bw_review_excerpt', true);
+        $related_project = (int) get_post_meta($post->ID, 'bw_related_project', true);
+
+        // Projects list for native selector — only needed when ACF is not active
+        $projects = function_exists('get_field') ? [] : get_posts([
+            'post_type'      => self::POST_TYPE_PROJECTS,
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+            'orderby'        => 'title',
+            'order'          => 'ASC',
+            'no_found_rows'  => true,
+        ]);
 
         include __DIR__ . '/views/reviews-meta-box.php';
     }
@@ -806,6 +817,16 @@ JS;
         // bw_review_excerpt: textarea ~150 chars
         if (isset($_POST['bw_review_excerpt'])) {
             update_post_meta($post_id, 'bw_review_excerpt', sanitize_textarea_field($_POST['bw_review_excerpt']));
+        }
+
+        // bw_related_project: native meta box (only active when ACF is not installed)
+        if (isset($_POST['bw_related_project'])) {
+            $project_id = absint($_POST['bw_related_project']);
+            if ($project_id > 0) {
+                update_post_meta($post_id, 'bw_related_project', $project_id);
+            } else {
+                delete_post_meta($post_id, 'bw_related_project');
+            }
         }
     }
 

--- a/site-essentials/Modules/CustomPosts/Review_Schema_Graph.php
+++ b/site-essentials/Modules/CustomPosts/Review_Schema_Graph.php
@@ -1,5 +1,5 @@
 <?php
-// v1.1 | 2026-06-01
+// v1.2 | 2026-06-18
 
 /**
  * Review schema token resolver.
@@ -13,8 +13,9 @@
  *   associated bw_reviews data, and returns a PHP array of schema.org
  *   Review objects. Usage:
  *     { "@type": "Service", "review": "%%_scos_review_cards_json%%" }
- *   Only "specific" mode elements contribute (loop-mode cards don't hold an
- *   explicit post ID and cannot be resolved at schema-output time).
+ *   "specific" mode elements contribute an explicit review ID.
+ *   "connected" mode elements contribute all reviews linked to the page's
+ *   project post via the bw_related_project meta key.
  *
  * %%_scos_aggregate_rating_json%%
  *   Queries all published bw_reviews posts, calculates the count and average
@@ -127,10 +128,14 @@ class Review_Schema_Graph {
 
 	/**
 	 * Read `_breakdance_data` for the page and collect bw_reviews post IDs
-	 * from every ScosReviewCard element configured in "specific" mode.
+	 * from every ScosReviewCard element.
+	 *
+	 * - "specific" mode: collects the explicit review_id stored in element props.
+	 * - "connected" mode: queries bw_reviews where bw_related_project = $post_id.
+	 * - "loop" mode: no explicit ID — skipped for schema purposes.
 	 *
 	 * Returns an empty array on any decode error or when no matching element
-	 * is found — these are "no reviews from BD" outcomes, not errors.
+	 * is found.
 	 *
 	 * @param int $post_id Page post ID.
 	 * @return int[]
@@ -156,8 +161,15 @@ class Review_Schema_Graph {
 			return [];
 		}
 
-		$collected = [];
-		self::walk_bd_tree( $tree, $collected );
+		$collected    = [];
+		$has_connected = false;
+		self::walk_bd_tree( $tree, $collected, $has_connected );
+
+		// For connected-mode elements, query reviews linked to this project.
+		if ( $has_connected ) {
+			$connected_ids = self::get_connected_review_ids( $post_id );
+			$collected     = array_merge( $collected, $connected_ids );
+		}
 
 		return $collected;
 	}
@@ -193,27 +205,26 @@ class Review_Schema_Graph {
 	}
 
 	/**
-	 * Recursively walk the BD tree, collecting review IDs from ScosReviewCard
-	 * nodes that are configured in "specific" mode.
+	 * Recursively walk the BD tree, collecting review IDs from ScosReviewCard nodes.
 	 *
-	 * Tolerates both fully-qualified and short class-name `type` values, and
-	 * accepts both `data.type` and flat `type` node shapes. Recurses into every
-	 * array value (not just `children`) for resilience across BD versions.
+	 * Sets $has_connected = true when any element uses "connected" mode.
+	 * Tolerates both fully-qualified and short class-name `type` values.
 	 *
-	 * @param array $node      Current tree fragment.
-	 * @param array $collected Reference; review IDs are appended.
+	 * @param array $node          Current tree fragment.
+	 * @param array $collected     Reference; review IDs are appended.
+	 * @param bool  $has_connected Reference; set to true when a connected-mode element is found.
 	 * @return void
 	 */
-	private static function walk_bd_tree( array $node, array &$collected ): void {
+	private static function walk_bd_tree( array $node, array &$collected, bool &$has_connected ): void {
 		$type = self::resolve_node_type( $node );
 
 		if ( self::BD_ELEMENT_TYPE === $type || self::BD_ELEMENT_TYPE_SHORT === $type ) {
-			self::harvest_review_node( $node, $collected );
+			self::harvest_review_node( $node, $collected, $has_connected );
 		}
 
 		foreach ( $node as $value ) {
 			if ( is_array( $value ) ) {
-				self::walk_bd_tree( $value, $collected );
+				self::walk_bd_tree( $value, $collected, $has_connected );
 			}
 		}
 	}
@@ -251,16 +262,18 @@ class Review_Schema_Graph {
 	}
 
 	/**
-	 * Extract the review post ID from a matched ScosReviewCard node.
+	 * Extract review data from a matched ScosReviewCard node.
 	 *
-	 * Only "specific" mode elements carry an explicit review ID.
-	 * Property path mirrors element.php: content.source.{mode, review_id}.
+	 * - "specific" mode: appends the explicit review_id to $collected.
+	 * - "connected" mode: sets $has_connected = true (IDs resolved later from meta).
+	 * - "loop" mode: no action (cannot resolve at schema-output time).
 	 *
-	 * @param array $node      The matched element node.
-	 * @param array $collected Reference; review IDs are appended.
+	 * @param array $node          The matched element node.
+	 * @param array $collected     Reference; review IDs are appended.
+	 * @param bool  $has_connected Reference; set to true for connected-mode elements.
 	 * @return void
 	 */
-	private static function harvest_review_node( array $node, array &$collected ): void {
+	private static function harvest_review_node( array $node, array &$collected, bool &$has_connected ): void {
 		$properties = [];
 		if ( isset( $node['data']['properties'] ) && is_array( $node['data']['properties'] ) ) {
 			$properties = $node['data']['properties'];
@@ -278,6 +291,11 @@ class Review_Schema_Graph {
 
 		$mode = isset( $source['mode'] ) ? (string) $source['mode'] : 'loop';
 
+		if ( 'connected' === $mode ) {
+			$has_connected = true;
+			return;
+		}
+
 		if ( 'specific' !== $mode || empty( $source['review_id'] ) ) {
 			return;
 		}
@@ -286,6 +304,31 @@ class Review_Schema_Graph {
 		if ( $id > 0 ) {
 			$collected[] = $id;
 		}
+	}
+
+	/**
+	 * Query bw_reviews posts linked to a project via bw_related_project meta.
+	 *
+	 * @param int $project_id The project post ID.
+	 * @return int[]
+	 */
+	private static function get_connected_review_ids( int $project_id ): array {
+		$query = new \WP_Query( [
+			'post_type'              => 'bw_reviews',
+			'post_status'            => 'publish',
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'meta_query'             => [ [
+				'key'     => 'bw_related_project',
+				'value'   => $project_id,
+				'compare' => '=',
+				'type'    => 'NUMERIC',
+			] ],
+		] );
+		return array_map( 'intval', (array) $query->posts );
 	}
 
 	/**

--- a/site-essentials/Modules/CustomPosts/views/reviews-meta-box.php
+++ b/site-essentials/Modules/CustomPosts/views/reviews-meta-box.php
@@ -6,16 +6,18 @@
  *
  * Variables available (set in render_reviews_meta_box before include):
  *
- * @var WP_Post $post            Current post
- * @var string  $rating          bw_rating value (1–5)
- * @var string  $date            bw_date value (YYYY-MM-DD)
- * @var string  $date_precision  bw_date_precision value (year|month-year|full)
- * @var string  $verify_url      bw_verify_url value
- * @var string  $schema_id       bw_schema_id value
- * @var string  $success_outcome bw_success_outcome value
- * @var string  $customer_detail bw_customer_detail value
- * @var string  $is_featured     bw_is_featured value (1|0|'')
- * @var string  $review_excerpt  bw_review_excerpt value
+ * @var WP_Post  $post            Current post
+ * @var string   $rating          bw_rating value (1–5)
+ * @var string   $date            bw_date value (YYYY-MM-DD)
+ * @var string   $date_precision  bw_date_precision value (year|month-year|full)
+ * @var string   $verify_url      bw_verify_url value
+ * @var string   $schema_id       bw_schema_id value
+ * @var string   $success_outcome bw_success_outcome value
+ * @var string   $customer_detail bw_customer_detail value
+ * @var string   $is_featured     bw_is_featured value (1|0|'')
+ * @var string   $review_excerpt  bw_review_excerpt value
+ * @var int      $related_project bw_related_project value (project post ID, 0 when none)
+ * @var WP_Post[] $projects        Published projects list (empty when ACF is active)
  *
  * @package    SiteEssentials
  * @subpackage Modules\CustomPosts
@@ -34,6 +36,32 @@ if (!defined('ABSPATH')) {
 <div class="bw-reviews-meta">
     <table class="form-table" role="presentation">
         <tbody>
+
+            <!-- ── Related Project (native — only shown when ACF is not active) ── -->
+            <?php if ( ! function_exists( 'get_field' ) && ! empty( $projects ) ) : ?>
+            <tr>
+                <th scope="row">
+                    <label for="bw_related_project"><?php esc_html_e( 'Related Project', 'site-essentials' ); ?></label>
+                </th>
+                <td>
+                    <select id="bw_related_project" name="bw_related_project">
+                        <option value="0"><?php esc_html_e( '— None —', 'site-essentials' ); ?></option>
+                        <?php foreach ( $projects as $project ) : ?>
+                        <option value="<?php echo esc_attr( $project->ID ); ?>"
+                                <?php selected( $related_project, $project->ID ); ?>>
+                            <?php echo esc_html( $project->post_title ); ?>
+                        </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <p class="description"><?php esc_html_e( 'Link this review to a project/success story. Used to display reviews on project single templates.', 'site-essentials' ); ?></p>
+                </td>
+            </tr>
+            <?php elseif ( ! function_exists( 'get_field' ) ) : ?>
+            <tr>
+                <th scope="row"><?php esc_html_e( 'Related Project', 'site-essentials' ); ?></th>
+                <td><p class="description"><?php esc_html_e( 'No published projects found. Create a project first.', 'site-essentials' ); ?></p></td>
+            </tr>
+            <?php endif; ?>
 
             <!-- ── Rating ────────────────────────────────────────── -->
             <tr>


### PR DESCRIPTION
## Summary

Adds a no-ACF path for linking `bw_reviews` posts to `projects` posts, and extends the schema graph to resolve connected reviews on project singles.

- **`Cpt_Module.php`** — `render_reviews_meta_box()` now loads `$related_project` (int) from `bw_related_project` meta and builds a `$projects` list via `get_posts()` — only when ACF is NOT active (`get_field()` absent). `save_reviews_meta()` saves or deletes `bw_related_project` via `absint()` guard. ACF `post_object` field continues to own the UI when ACF is installed (same meta key, zero conflict).

- **`views/reviews-meta-box.php`** — Added a "Related Project" `<select>` row at the top of the meta box, wrapped in `if ( ! function_exists( 'get_field' ) && ! empty( $projects ) )` so it only renders without ACF.

- **`Review_Schema_Graph.php`** (v1.1 → v1.2) — Extended `collect_review_ids_from_breakdance()` to detect any `connected`-mode `ScosReviewCard` element in the page's Breakdance data and query all reviews linked to the current project via `bw_related_project` meta. New private `get_connected_review_ids()` helper.

## Meta key

`bw_related_project` — stores the related project post ID as a plain integer on the `bw_reviews` post. Pre-existing ACF fallback key; no migration needed.

## Test plan

- [ ] With ACF inactive: edit a `bw_reviews` post → "Related Project" `<select>` appears in Review Details meta box; save → `bw_related_project` meta written correctly; set to "None" → meta deleted
- [ ] With ACF active: "Related Project" `<select>` does NOT appear (ACF field takes over)
- [ ] On a project single with a `ScosReviewCard` element in `connected` mode, `Review_Schema_Graph` emits schema for all reviews linked to that project
- [ ] On a project single with no connected reviews, schema output is empty / gracefully absent

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dm8V6WkBt2q3oHBjHxmmdv)_