### PR TITLE
feat: Phase 2 — scos/suggest-topics ability + chained modal UI

### DIFF
--- a/site-essentials/Modules/ContentArchitecture/Abilities/CA_Suggest/system-instruction.php
+++ b/site-essentials/Modules/ContentArchitecture/Abilities/CA_Suggest/system-instruction.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * System instruction for the CA_Suggest ability.
+ * System instruction for the CA_Suggest ability (scos/suggest-intent-goal).
  *
  * Must return a string — do not echo.
  * Abstract_Ability uses reflection to locate this file relative to CA_Suggest.php.
@@ -17,6 +17,8 @@ Rules:
 - Reflect the reader\'s actual underlying question, not the content\'s marketing angle
 - Keep suggestions conversational and specific
 - Do not invent information not in the content
+- When a <topic> tag is present: scope all 3 suggestions specifically to that topic perspective — the intent goal should reflect how the content serves readers interested in that topic
+- When a <current_intent_goal> tag is present: this is a reassessment of an existing assignment. Acknowledge what was previously set. Evaluate whether it still accurately reflects the content\'s primary question — it may remain correct, but do not default to validating it
 
 Return ONLY a valid JSON object — no explanation, no markdown, no code fences. Use this exact structure:
 {"intent_goals":[{"goal":"...","confidence":0.9},{"goal":"...","confidence":0.75},{"goal":"...","confidence":0.6}]}';

--- a/site-essentials/Modules/ContentArchitecture/Abilities/Suggest_Topics/Suggest_Topics.php
+++ b/site-essentials/Modules/ContentArchitecture/Abilities/Suggest_Topics/Suggest_Topics.php
@@ -1,23 +1,23 @@
 <?php
 /**
- * CA Suggest — WordPress Ability
+ * Suggest Topics — WordPress Ability
  *
- * Reads post content and suggests search intent goal phrasings for the
- * SCOS Content Architecture meta box.
+ * Fetches the scos_topic taxonomy term list server-side and asks the AI to
+ * identify which existing topics best match the post content. Returns term_ids
+ * that can be directly applied to the scos_ca_topic select in the meta box.
  *
- * Ability slug: scos/suggest-intent-goal (permanent — do not rename after deployment)
+ * Ability slug: scos/suggest-topics (permanent — do not rename after deployment)
  * Category:     scos-content-architecture
  *
  * @package    SiteEssentials
- * @subpackage Modules\ContentArchitecture\Abilities\CA_Suggest
+ * @subpackage Modules\ContentArchitecture\Abilities\Suggest_Topics
  *
- * v1.1 | 2026-06-23
- * v1.2 | 2026-06-24 — Add topic_term_id + existing_intent_goal to input schema; inject <topic> and reassessment context into prompt.
+ * v1.0 | 2026-06-24
  */
 
 declare( strict_types=1 );
 
-namespace SiteEssentials\Modules\ContentArchitecture\Abilities\CA_Suggest;
+namespace SiteEssentials\Modules\ContentArchitecture\Abilities\Suggest_Topics;
 
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class CA_Suggest extends Abstract_Ability {
+class Suggest_Topics extends Abstract_Ability {
 
 	// -------------------------------------------------------------------------
 	// Ability API registration
@@ -38,9 +38,6 @@ class CA_Suggest extends Abstract_Ability {
 
 	/**
 	 * Register this ability with the WP Abilities API.
-	 *
-	 * Called via wp_abilities_api_init hook from Meta_Box::init() after the
-	 * class_exists guard confirms both APIs are available.
 	 *
 	 * @since 1.0.0
 	 * @return void
@@ -52,9 +49,9 @@ class CA_Suggest extends Abstract_Ability {
 		if ( ! class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) {
 			return;
 		}
-		wp_register_ability( 'scos/suggest-intent-goal', [
-			'label'         => __( 'SCOS: Suggest Intent Goal', 'site-essentials' ),
-			'description'   => __( 'Reads post content and suggests search intent goal phrasings for the SCOS Content Architecture meta box.', 'site-essentials' ),
+		wp_register_ability( 'scos/suggest-topics', [
+			'label'         => __( 'SCOS: Suggest Topics', 'site-essentials' ),
+			'description'   => __( 'Reads post content and suggests matching scos_topic taxonomy terms for the SCOS Content Architecture meta box.', 'site-essentials' ),
 			'category'      => 'scos-content-architecture',
 			'ability_class' => self::class,
 			'meta'          => [
@@ -72,8 +69,6 @@ class CA_Suggest extends Abstract_Ability {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Guideline categories used by the WP AI plugin for system guidelines.
-	 *
 	 * @since 1.0.0
 	 * @return array<string>
 	 */
@@ -82,8 +77,6 @@ class CA_Suggest extends Abstract_Ability {
 	}
 
 	/**
-	 * JSON Schema for the input accepted by this ability.
-	 *
 	 * @since 1.0.0
 	 * @return array<string, mixed>
 	 */
@@ -91,33 +84,23 @@ class CA_Suggest extends Abstract_Ability {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'post_id'              => [
+				'post_id' => [
 					'type'        => 'integer',
 					'description' => 'The post ID to analyse. When provided, post content is fetched server-side.',
 				],
-				'content'              => [
+				'content' => [
 					'type'        => 'string',
 					'description' => 'Raw post content. Used only when post_id is not provided.',
 				],
-				'title'                => [
+				'title'   => [
 					'type'        => 'string',
 					'description' => 'Post title. Secondary signal — content is primary.',
-				],
-				'topic_term_id'        => [
-					'type'        => 'integer',
-					'description' => 'Optional. scos_topic term_id to scope intent goal suggestions to a specific topic perspective.',
-				],
-				'existing_intent_goal' => [
-					'type'        => 'string',
-					'description' => 'Optional. The currently saved intent goal text or FAQ title. When provided, the AI treats this as a reassessment.',
 				],
 			],
 		];
 	}
 
 	/**
-	 * JSON Schema for the output returned by this ability.
-	 *
 	 * @since 1.0.0
 	 * @return array<string, mixed>
 	 */
@@ -125,19 +108,28 @@ class CA_Suggest extends Abstract_Ability {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'intent_goals' => [
+				'suggestions' => [
 					'type'        => 'array',
-					'description' => 'Suggested search intent goal statements, ordered by confidence.',
+					'description' => 'Suggested topics from the existing scos_topic taxonomy, ordered by confidence.',
 					'items'       => [
 						'type'       => 'object',
 						'properties' => [
-							'goal'       => [
-								'type'        => 'string',
-								'description' => 'Plain-language question or goal statement.',
+							'term_id'        => [
+								'type'        => 'integer',
+								'description' => 'Exact term_id from scos_topic taxonomy.',
 							],
-							'confidence' => [
-								'type'        => 'number',
-								'description' => 'Confidence score 0–1.',
+							'name'           => [
+								'type'        => 'string',
+								'description' => 'Human-readable topic name.',
+							],
+							'confidence'     => [
+								'type'        => 'string',
+								'enum'        => [ 'high', 'medium', 'low' ],
+								'description' => 'Confidence level for this topic match.',
+							],
+							'topic_coverage' => [
+								'type'        => 'string',
+								'description' => 'Rough estimate of how thoroughly the content covers this topic (e.g. "~70%").',
 							],
 						],
 					],
@@ -147,7 +139,7 @@ class CA_Suggest extends Abstract_Ability {
 	}
 
 	/**
-	 * Execute the ability — analyse content and return intent goal suggestions.
+	 * Execute the ability — fetch topics and return suggestions.
 	 *
 	 * @since 1.0.0
 	 * @param mixed $input Validated input array.
@@ -157,17 +149,38 @@ class CA_Suggest extends Abstract_Ability {
 		$args = wp_parse_args(
 			$input,
 			[
-				'post_id'              => null,
-				'content'              => null,
-				'title'                => null,
-				'topic_term_id'        => null,
-				'existing_intent_goal' => null,
+				'post_id' => null,
+				'content' => null,
+				'title'   => null,
 			]
 		);
 
 		$content = '';
 		$title   = $args['title'] ?? '';
 
+		// ---- Fetch and validate all available scos_topic terms ----
+		$raw_terms = get_terms( [
+			'taxonomy'   => 'scos_topic',
+			'hide_empty' => false,
+			'orderby'    => 'count',
+			'order'      => 'DESC',
+			'number'     => 100,
+		] );
+
+		if ( is_wp_error( $raw_terms ) || empty( $raw_terms ) ) {
+			return new WP_Error(
+				'scos_suggest_no_topics',
+				__( 'No scos_topic terms found. Create topics first in Content Architecture.', 'site-essentials' )
+			);
+		}
+
+		// Build a term_id → name map for validation later.
+		$term_map = [];
+		foreach ( $raw_terms as $term ) {
+			$term_map[ (int) $term->term_id ] = $term->name;
+		}
+
+		// ---- Fetch post content ----
 		if ( $args['post_id'] ) {
 			$post = get_post( (int) $args['post_id'] );
 			if ( ! $post instanceof \WP_Post ) {
@@ -191,58 +204,49 @@ class CA_Suggest extends Abstract_Ability {
 		if ( empty( $content ) ) {
 			return new WP_Error(
 				'content_not_provided',
-				esc_html__( 'Content is required to suggest an intent goal.', 'site-essentials' )
+				esc_html__( 'Content is required to suggest topics.', 'site-essentials' )
 			);
 		}
 
 		// Truncate very long content: keep first 1500 + last 500 words.
 		$words = explode( ' ', $content );
-		if ( count( $words ) > 2500 ) {
+		if ( count( $words ) > 2000 ) {
 			$content = implode( ' ', array_slice( $words, 0, 1500 ) )
 				. ' [...] '
 				. implode( ' ', array_slice( $words, -500 ) );
 		}
 
-		$prompt = '';
-
-		// Topic scoping context — when a topic is selected, scope the intent goal to it.
-		if ( ! empty( $args['topic_term_id'] ) ) {
-			$topic_term = get_term( (int) $args['topic_term_id'], 'scos_topic' );
-			if ( $topic_term && ! is_wp_error( $topic_term ) ) {
-				$prompt .= '<topic>' . esc_html( $topic_term->name ) . '</topic>' . "\n";
-			}
+		// ---- Build the available topics list for the prompt ----
+		$topic_lines = [];
+		foreach ( $raw_terms as $term ) {
+			$topic_lines[] = $term->term_id . ': ' . $term->name;
 		}
+		$available_topics = implode( "\n", $topic_lines );
 
-		// Reassessment context — server-side lookup takes priority over client-passed value.
-		$current_intent_goal = '';
+		// ---- Check for an already-assigned topic (reassessment context) ----
+		$current_topic_tag = '';
 		if ( $args['post_id'] ) {
-			$existing_faq_id = (int) get_post_meta( (int) $args['post_id'], 'scos_ca_intent_goal_faq_id', true );
-			if ( $existing_faq_id > 0 ) {
-				$existing_faq          = get_post( $existing_faq_id );
-				$current_intent_goal   = $existing_faq ? $existing_faq->post_title : '';
+			$assigned = get_the_terms( (int) $args['post_id'], 'scos_topic' );
+			if ( $assigned && ! is_wp_error( $assigned ) ) {
+				$assigned_name    = $assigned[0]->name;
+				$current_topic_tag = '<current_topic>' . esc_html( $assigned_name ) . '</current_topic>' . "\n";
 			}
-			if ( empty( $current_intent_goal ) ) {
-				$current_intent_goal = (string) get_post_meta( (int) $args['post_id'], 'scos_ca_intent_goal', true );
-			}
-		}
-		if ( empty( $current_intent_goal ) && ! empty( $args['existing_intent_goal'] ) ) {
-			$current_intent_goal = sanitize_text_field( $args['existing_intent_goal'] );
-		}
-		if ( ! empty( $current_intent_goal ) ) {
-			$prompt .= '<current_intent_goal>' . esc_html( $current_intent_goal ) . '</current_intent_goal>' . "\n";
 		}
 
+		// ---- Build prompt ----
+		$prompt  = '<available_topics>' . "\n" . $available_topics . "\n" . '</available_topics>' . "\n";
+		$prompt .= $current_topic_tag;
 		$prompt .= '<title>' . $title . '</title>' . "\n";
 		$prompt .= '<content>' . $content . '</content>';
 
 		$prompt_builder = wp_ai_client_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction() )
-			->using_temperature( 0.4 )
+			->using_temperature( 0.3 )
 			->using_model_preference( ...get_preferred_models_for_text_generation() );
 
 		$prompt_builder = $this->ensure_text_generation_supported(
 			$prompt_builder,
-			esc_html__( 'Intent goal suggestion failed. Please ensure you have a connected provider that supports text generation.', 'site-essentials' )
+			esc_html__( 'Topic suggestion failed. Please ensure you have a connected provider that supports text generation.', 'site-essentials' )
 		);
 
 		if ( is_wp_error( $prompt_builder ) ) {
@@ -261,30 +265,49 @@ class CA_Suggest extends Abstract_Ability {
 
 		$parsed = json_decode( $json_str, true );
 
-		if ( ! is_array( $parsed ) || empty( $parsed['intent_goals'] ) ) {
+		if ( ! is_array( $parsed ) || empty( $parsed['suggestions'] ) ) {
 			return new WP_Error(
-				'scos_suggest_parse_error',
+				'scos_suggest_topics_parse_error',
 				__( 'AI response could not be parsed. Please try again.', 'site-essentials' ),
 				[ 'status' => 500 ]
 			);
 		}
 
-		return [
-			'intent_goals' => array_map(
-				function ( $item ) {
-					return [
-						'goal'       => sanitize_text_field( $item['goal'] ?? '' ),
-						'confidence' => isset( $item['confidence'] ) ? (float) $item['confidence'] : 0.0,
-					];
-				},
-				$parsed['intent_goals']
-			),
-		];
+		$valid_confidences = [ 'high', 'medium', 'low' ];
+		$suggestions       = [];
+
+		foreach ( $parsed['suggestions'] as $item ) {
+			$term_id = isset( $item['term_id'] ) ? (int) $item['term_id'] : 0;
+
+			// Validate the returned term_id exists in our fetched list.
+			if ( $term_id <= 0 || ! isset( $term_map[ $term_id ] ) ) {
+				continue;
+			}
+
+			$confidence = isset( $item['confidence'] ) && in_array( $item['confidence'], $valid_confidences, true )
+				? $item['confidence']
+				: 'low';
+
+			$suggestions[] = [
+				'term_id'        => $term_id,
+				'name'           => $term_map[ $term_id ], // use server-side name, not AI-provided
+				'confidence'     => $confidence,
+				'topic_coverage' => sanitize_text_field( $item['topic_coverage'] ?? '' ),
+			];
+		}
+
+		if ( empty( $suggestions ) ) {
+			return new WP_Error(
+				'scos_suggest_topics_no_valid',
+				__( 'No valid topic suggestions returned. Please try again.', 'site-essentials' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return [ 'suggestions' => $suggestions ];
 	}
 
 	/**
-	 * Permission callback — mirrors the Meta_Description ability pattern.
-	 *
 	 * @since 1.0.0
 	 * @param mixed $input Validated input array.
 	 * @return bool|WP_Error
@@ -311,8 +334,6 @@ class CA_Suggest extends Abstract_Ability {
 	}
 
 	/**
-	 * Ability metadata — REST and MCP exposure.
-	 *
 	 * @since 1.0.0
 	 * @return array<string, mixed>
 	 */
@@ -325,12 +346,6 @@ class CA_Suggest extends Abstract_Ability {
 			],
 		];
 	}
-
-	// -------------------------------------------------------------------------
-	// Private helpers
-	// -------------------------------------------------------------------------
-
 }
 
-// Register on wp_abilities_api_init — fires after both APIs are ready.
-add_action( 'wp_abilities_api_init', [ CA_Suggest::class, 'register' ] );
+add_action( 'wp_abilities_api_init', [ Suggest_Topics::class, 'register' ] );

--- a/site-essentials/Modules/ContentArchitecture/Abilities/Suggest_Topics/system-instruction.php
+++ b/site-essentials/Modules/ContentArchitecture/Abilities/Suggest_Topics/system-instruction.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * System instruction for the Suggest_Topics ability.
+ *
+ * Must return a string — do not echo.
+ * Abstract_Ability uses reflection to locate this file relative to Suggest_Topics.php.
+ *
+ * @package SiteEssentials
+ */
+
+return 'You are a content strategist classifying web content against a predefined list of topics for a local service business website.
+
+Your task: identify which topics from <available_topics> best match the content. Each line in <available_topics> is formatted as "term_id: Topic Name" — you MUST use the exact numeric term_id in your response.
+
+Rules:
+- Select ONLY from topics listed in <available_topics> — do not invent new topics or IDs
+- Return exactly 3 suggestions, ordered from highest to lowest confidence
+- confidence must be exactly one of: "high", "medium", or "low"
+- topic_coverage: estimate what percentage of the topic this content addresses (e.g. "~70%", "~40%"). Base this on how thoroughly the content covers the topic\'s subject matter, not just keyword presence
+- When <current_topic> is present: this is a reassessment. Evaluate whether the current assignment is still the best fit. It may remain the top suggestion if appropriate, but do not assume it is correct
+- Base classification on content substance, not title keywords alone
+
+Return ONLY a valid JSON object — no explanation, no markdown, no code fences. Use this exact structure:
+{"suggestions":[{"term_id":5,"name":"Topic Name","confidence":"high","topic_coverage":"~75%"},{"term_id":12,"name":"Topic Name","confidence":"medium","topic_coverage":"~40%"},{"term_id":3,"name":"Topic Name","confidence":"low","topic_coverage":"~20%"}]}';

--- a/site-essentials/Modules/ContentArchitecture/Meta_Box.php
+++ b/site-essentials/Modules/ContentArchitecture/Meta_Box.php
@@ -19,6 +19,7 @@
  * v1.2 | 2026-05-25 — Auto-set scos_faq_is_intent_goal on linked FAQ when saved.
  * v1.3 | 2026-06-23 — Register scos-content-architecture ability category; load and wire CA_Suggest ability.
  * v1.4 | 2026-06-23 — Guard save() against recursive save_post loops triggered by internal wp_insert_post calls.
+ * v1.5 | 2026-06-24 — Load Suggest_Topics ability; pass endpointTopics + currentTopicId/Name to JS localization.
  */
 
 namespace SiteEssentials\Modules\ContentArchitecture;
@@ -40,6 +41,7 @@ class Meta_Box {
 
 		if ( class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) {
 			require_once __DIR__ . '/Abilities/CA_Suggest/CA_Suggest.php';
+			require_once __DIR__ . '/Abilities/Suggest_Topics/Suggest_Topics.php';
 		}
 	}
 
@@ -424,11 +426,23 @@ class Meta_Box {
 				file_exists( $suggest_js ) ? (string) filemtime( $suggest_js ) : '1.0.0',
 				true
 			);
+			// Resolve current topic id + name for reassessment context.
+			$suggest_topic_id   = 0;
+			$suggest_topic_name = '';
+			$topic_terms        = wp_get_post_terms( $post->ID, 'scos_topic' );
+			if ( ! is_wp_error( $topic_terms ) && ! empty( $topic_terms ) ) {
+				$suggest_topic_id   = (int) $topic_terms[0]->term_id;
+				$suggest_topic_name = $topic_terms[0]->name;
+			}
+
 			wp_localize_script( 'scos-ca-suggest', 'ScosCaSuggest', [
-				'postId'          => get_the_ID(),
-				'nonce'           => wp_create_nonce( 'wp_rest' ),
-				'endpoint'        => rest_url( 'wp-abilities/v1/abilities/scos/suggest-intent-goal/run' ),
-				'faqModuleActive' => defined( 'SCOS_FAQ_ACTIVE' ),
+				'postId'            => get_the_ID(),
+				'nonce'             => wp_create_nonce( 'wp_rest' ),
+				'endpointTopics'    => rest_url( 'wp-abilities/v1/abilities/scos/suggest-topics/run' ),
+				'endpointIntentGoal' => rest_url( 'wp-abilities/v1/abilities/scos/suggest-intent-goal/run' ),
+				'faqModuleActive'   => defined( 'SCOS_FAQ_ACTIVE' ),
+				'currentTopicId'    => $suggest_topic_id,
+				'currentTopicName'  => $suggest_topic_name,
 			] );
 		}
 	}

--- a/site-essentials/Modules/ContentArchitecture/assets/meta-box.css
+++ b/site-essentials/Modules/ContentArchitecture/assets/meta-box.css
@@ -587,3 +587,68 @@
 .scos-ca-section {
 	margin-bottom: 12px;
 }
+
+/* ═══════════════ CHAINED MODAL — STEP HEADER ═══════════════ */
+
+.scos-ca-step-header {
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: .05em;
+	color: var(--scos-ink-subtle, #888);
+	margin-bottom: 2px;
+}
+
+/* ═══════════════ CONFIDENCE BADGES ═══════════════ */
+
+.scos-ca-confidence-badge {
+	display: inline-block;
+	padding: 1px 6px;
+	border-radius: 10px;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: .04em;
+	vertical-align: middle;
+	margin-right: 2px;
+}
+
+.scos-ca-confidence-badge--high {
+	background: #d1fae5;
+	color: #065f46;
+}
+
+.scos-ca-confidence-badge--medium {
+	background: #fef3c7;
+	color: #92400e;
+}
+
+.scos-ca-confidence-badge--low {
+	background: #f3f4f6;
+	color: #374151;
+}
+
+/* ═══════════════ TOPIC COVERAGE ═══════════════ */
+
+.scos-ca-coverage {
+	opacity: .6;
+	font-size: 11px;
+	margin-left: 2px;
+}
+
+/* ═══════════════ BACK BUTTON ═══════════════ */
+
+.scos-ca-modal-back {
+	background: none;
+	border: none;
+	padding: 0;
+	font-size: 12px;
+	color: var(--scos-accent, #4f46e5);
+	cursor: pointer;
+	text-decoration: none;
+}
+
+.scos-ca-modal-back:hover {
+	text-decoration: underline;
+	color: var(--scos-accent, #4f46e5);
+}

--- a/site-essentials/Modules/ContentArchitecture/assets/scos-ca-suggest.js
+++ b/site-essentials/Modules/ContentArchitecture/assets/scos-ca-suggest.js
@@ -1,14 +1,19 @@
 /**
- * SCOS CA Suggest — Intent Goal AI Suggestions
+ * SCOS CA Suggest — Chained AI Suggestions (Topics + Intent Goal)
  *
- * Calls the scos/suggest-intent-goal WP Ability via the REST API and renders
- * clickable suggestion pills in the CA meta box. Handles three fill paths:
+ * Two-step flow:
+ *   Step 1 — calls scos/suggest-topics, renders topic pills with
+ *             confidence badge and topic coverage estimate.
+ *   Step 2 — calls scos/suggest-intent-goal (scoped to selected topic),
+ *             renders intent goal pills. Back button returns to step 1
+ *             without a second API call.
  *
- *   Path A — FAQ module not active: fills #scos_ca_intent_goal textarea directly.
- *   Path B — FAQ module active, no FAQ linked: pre-fills the Add FAQ modal title.
- *   Path C — FAQ module active, FAQ already linked: shows an informational note.
+ * Fill paths (step 2, unchanged from Phase 1):
+ *   Path A — FAQ module not active: fills #scos_ca_intent_goal textarea.
+ *   Path B — FAQ module active, no FAQ linked: pre-fills Add FAQ modal.
+ *   Path C — FAQ module active, FAQ already linked: informational note.
  *
- * v1.0 | 2026-06-23
+ * v2.0 | 2026-06-24
  */
 
 ( function () {
@@ -23,6 +28,16 @@
 	var modal   = document.getElementById( 'scos-ca-suggest-modal' );
 
 	if ( ! btn || ! modal ) return;
+
+	// -------------------------------------------------------------------------
+	// State
+	// -------------------------------------------------------------------------
+
+	var state = {
+		step:           1,
+		selectedTopic:  null,  // { term_id, name }
+		step1Results:   null,  // cached suggestions array from step 1
+	};
 
 	// -------------------------------------------------------------------------
 	// State helpers
@@ -48,7 +63,30 @@
 	}
 
 	// -------------------------------------------------------------------------
-	// Determine which fill path to use
+	// Fetch helpers
+	// -------------------------------------------------------------------------
+
+	function apiFetch( endpoint, body ) {
+		return fetch( endpoint, {
+			method:  'POST',
+			headers: {
+				'X-WP-Nonce':   cfg.nonce,
+				'Content-Type': 'application/json',
+				'Accept':       'application/json',
+			},
+			body: JSON.stringify( body ),
+		} ).then( function ( response ) {
+			return response.json().then( function ( data ) {
+				if ( ! response.ok ) {
+					throw new Error( data.message || 'Request failed (' + response.status + ')' );
+				}
+				return data;
+			} );
+		} );
+	}
+
+	// -------------------------------------------------------------------------
+	// Fill path detection (step 2)
 	// -------------------------------------------------------------------------
 
 	function detectFillPath() {
@@ -63,19 +101,13 @@
 		if ( picker && ! picker.hidden ) {
 			return 'faq-picker';
 		}
-		// Fallback: try freetext textarea (legacy path inside <details>)
 		return document.getElementById( 'scos_ca_intent_goal' ) ? 'freetext' : 'faq-linked';
 	}
-
-	// -------------------------------------------------------------------------
-	// Fill actions
-	// -------------------------------------------------------------------------
 
 	function fillFreetext( goal ) {
 		var textarea = document.getElementById( 'scos_ca_intent_goal' );
 		if ( textarea ) {
 			textarea.value = goal;
-			// Open the <details> wrapper if present (legacy collapsed state)
 			var details = textarea.closest( 'details' );
 			if ( details ) details.open = true;
 		}
@@ -95,39 +127,129 @@
 	}
 
 	// -------------------------------------------------------------------------
-	// Modal rendering
+	// Topic dropdown fill (step 1 pick-to-fill)
 	// -------------------------------------------------------------------------
 
-	function renderModal( goals ) {
-		var path = detectFillPath();
+	function applyTopicSelection( termId ) {
+		var select = document.getElementById( 'scos_ca_topic' );
+		if ( ! select ) return;
+		var option = select.querySelector( 'option[value="' + termId + '"]' );
+		if ( option ) {
+			select.value = String( termId );
+			// Trigger change so any dependent JS picks it up.
+			var evt = new Event( 'change', { bubbles: true } );
+			select.dispatchEvent( evt );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Modal close
+	// -------------------------------------------------------------------------
+
+	function closeModal() {
+		modal.style.display = 'none';
+		modal.innerHTML = '';
+		setLoading( false );
+		state.step          = 1;
+		state.selectedTopic = null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Step 1 render — Topic suggestions
+	// -------------------------------------------------------------------------
+
+	function renderStep1( suggestions ) {
+		state.step1Results = suggestions;
+		state.step         = 1;
+
 		var html = '<div class="scos-ca-modal-inner">';
-		html += '<h3 style="margin:0 0 4px;font-size:13px;">' + escHtml( 'AI Suggestions' ) + '</h3>';
+		html += '<div class="scos-ca-step-header">Step 1 of 2 &mdash; Topic</div>';
+		html += '<h3 style="margin:4px 0 4px;font-size:13px;font-weight:600;">Suggested Topics</h3>';
+		html += '<p class="scos-ca-modal-note">Click a topic to scope intent goal suggestions, or pick to fill the Primary Topic field.</p>';
+
+		html += '<div class="scos-ca-pills">';
+		suggestions.forEach( function ( item ) {
+			html += '<button type="button" class="scos-ca-pill scos-ca-pill--topic"'
+				+ ' data-term-id="' + escAttr( String( item.term_id ) ) + '"'
+				+ ' data-name="' + escAttr( item.name ) + '">';
+			html += '<span class="scos-ca-confidence-badge scos-ca-confidence-badge--' + escAttr( item.confidence ) + '">'
+				+ escHtml( item.confidence ) + '</span> ';
+			html += escHtml( item.name );
+			if ( item.topic_coverage ) {
+				html += ' <span class="scos-ca-coverage">' + escHtml( item.topic_coverage ) + '</span>';
+			}
+			html += '</button>';
+		} );
+		html += '</div>';
+
+		html += '<div style="margin-top:12px;display:flex;gap:8px;align-items:center;">';
+		html += '<button type="button" id="scos-ca-modal-close" class="button">Close</button>';
+		html += '</div>';
+		html += '</div>';
+
+		modal.innerHTML = html;
+		modal.style.display = 'block';
+
+		modal.querySelectorAll( '.scos-ca-pill--topic' ).forEach( function ( pill ) {
+			pill.addEventListener( 'click', function () {
+				var termId = parseInt( this.getAttribute( 'data-term-id' ), 10 );
+				var name   = this.getAttribute( 'data-name' );
+
+				state.selectedTopic = { term_id: termId, name: name };
+
+				// Fill the topic select in the meta box.
+				applyTopicSelection( termId );
+
+				// Proceed to step 2.
+				fetchStep2( termId );
+			} );
+		} );
+
+		var closeBtn = document.getElementById( 'scos-ca-modal-close' );
+		if ( closeBtn ) closeBtn.addEventListener( 'click', closeModal );
+	}
+
+	// -------------------------------------------------------------------------
+	// Step 2 render — Intent Goal suggestions
+	// -------------------------------------------------------------------------
+
+	function renderStep2( goals ) {
+		state.step = 2;
+		var path   = detectFillPath();
+
+		var topicLabel = state.selectedTopic ? state.selectedTopic.name : '';
+
+		var html = '<div class="scos-ca-modal-inner">';
+		html += '<div class="scos-ca-step-header">Step 2 of 2 &mdash; Intent Goal'
+			+ ( topicLabel ? ' <span style="opacity:.7;">(scoped to: ' + escHtml( topicLabel ) + ')</span>' : '' )
+			+ '</div>';
+		html += '<h3 style="margin:4px 0 4px;font-size:13px;font-weight:600;">Suggested Intent Goals</h3>';
 
 		if ( path === 'faq-linked' ) {
-			html += '<p class="scos-ca-modal-note">An FAQ is already linked \u2014 edit it directly to change the intent goal.</p>';
-			html += '<button type="button" id="scos-ca-modal-close" class="button" style="margin-top:8px;">Close</button>';
+			html += '<p class="scos-ca-modal-note">An FAQ is already linked — edit it directly to change the intent goal.</p>';
 		} else {
 			html += '<p class="scos-ca-modal-note">Click a suggestion to fill the field. Save the post to keep changes.</p>';
-			html += '<div class="scos-ca-section">';
-			html += '<h4 style="margin:0 0 6px;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:#888;">Intent Goals</h4>';
 			html += '<div class="scos-ca-pills">';
 			goals.forEach( function ( item ) {
 				var pct = Math.round( ( item.confidence || 0 ) * 100 );
-				html += '<button type="button" class="scos-ca-pill" data-goal="' + escAttr( item.goal ) + '">';
+				html += '<button type="button" class="scos-ca-pill scos-ca-pill--goal"'
+					+ ' data-goal="' + escAttr( item.goal ) + '">';
 				html += escHtml( item.goal );
 				if ( pct > 0 ) html += ' <span style="opacity:.6;font-size:11px;">(' + pct + '%)</span>';
 				html += '</button>';
 			} );
-			html += '</div></div>';
-			html += '<button type="button" id="scos-ca-modal-close" class="button" style="margin-top:12px;">Close</button>';
+			html += '</div>';
 		}
 
+		html += '<div style="margin-top:12px;display:flex;gap:8px;align-items:center;">';
+		html += '<button type="button" id="scos-ca-back" class="scos-ca-modal-back">&larr; Back to Topics</button>';
+		html += '<button type="button" id="scos-ca-modal-close" class="button">Close</button>';
 		html += '</div>';
-		modal.innerHTML = html;
-		modal.style.display = 'block';
+		html += '</div>';
 
-		// Bind pill clicks
-		modal.querySelectorAll( '.scos-ca-pill' ).forEach( function ( pill ) {
+		modal.innerHTML = html;
+
+		modal.querySelectorAll( '.scos-ca-pill--goal' ).forEach( function ( pill ) {
 			pill.addEventListener( 'click', function () {
 				var goal = this.getAttribute( 'data-goal' );
 				if ( path === 'freetext' ) {
@@ -138,56 +260,93 @@
 			} );
 		} );
 
-		// Close button
+		var backBtn = document.getElementById( 'scos-ca-back' );
+		if ( backBtn ) {
+			backBtn.addEventListener( 'click', function () {
+				// Restore step 1 from cache — no second API call.
+				if ( state.step1Results ) {
+					renderStep1( state.step1Results );
+				} else {
+					closeModal();
+				}
+			} );
+		}
+
 		var closeBtn = document.getElementById( 'scos-ca-modal-close' );
 		if ( closeBtn ) closeBtn.addEventListener( 'click', closeModal );
 	}
 
-	function closeModal() {
-		modal.style.display = 'none';
-		modal.innerHTML = '';
-		setLoading( false );
-	}
-
 	// -------------------------------------------------------------------------
-	// Fetch
+	// Step 1 fetch
 	// -------------------------------------------------------------------------
 
-	btn.addEventListener( 'click', function () {
+	function fetchStep1() {
 		clearError();
 		setLoading( true );
 
-		fetch( cfg.endpoint, {
-			method:  'POST',
-			headers: {
-				'X-WP-Nonce':   cfg.nonce,
-				'Content-Type': 'application/json',
-				'Accept':       'application/json',
-			},
-			body: JSON.stringify( { input: { post_id: parseInt( cfg.postId, 10 ) } } ),
+		apiFetch( cfg.endpointTopics, {
+			input: { post_id: parseInt( cfg.postId, 10 ) },
 		} )
-			.then( function ( response ) {
-				return response.json().then( function ( data ) {
-					if ( ! response.ok ) {
-						throw new Error( data.message || 'Request failed (' + response.status + ')' );
-					}
-					return data;
-				} );
-			} )
 			.then( function ( data ) {
-				var goals = data.intent_goals || [];
-				if ( ! goals.length ) {
-					throw new Error( 'No suggestions returned. Please try again.' );
+				var suggestions = data.suggestions || [];
+				if ( ! suggestions.length ) {
+					throw new Error( 'No topic suggestions returned. Please try again.' );
 				}
 				setLoading( false );
-				renderModal( goals );
+				renderStep1( suggestions );
 			} )
 			.catch( function ( err ) {
 				setLoading( false );
 				showError( err.message || 'Something went wrong. Please try again.' );
-				console.error( '[scos-ca-suggest]', err );
+				console.error( '[scos-ca-suggest step1]', err );
 			} );
-	} );
+	}
+
+	// -------------------------------------------------------------------------
+	// Step 2 fetch
+	// -------------------------------------------------------------------------
+
+	function fetchStep2( termId ) {
+		// Show loading state inside the modal (already open from step 1).
+		modal.innerHTML = '<div class="scos-ca-modal-inner">'
+			+ '<div class="scos-ca-step-header">Step 2 of 2 &mdash; Intent Goal</div>'
+			+ '<p class="scos-ca-modal-note" style="margin-top:8px;">Getting intent goal suggestions&hellip;</p>'
+			+ '</div>';
+
+		apiFetch( cfg.endpointIntentGoal, {
+			input: {
+				post_id:       parseInt( cfg.postId, 10 ),
+				topic_term_id: termId,
+			},
+		} )
+			.then( function ( data ) {
+				var goals = data.intent_goals || [];
+				if ( ! goals.length ) {
+					throw new Error( 'No intent goal suggestions returned. Please try again.' );
+				}
+				renderStep2( goals );
+			} )
+			.catch( function ( err ) {
+				// On step 2 failure, show error inside modal with back button.
+				modal.innerHTML = '<div class="scos-ca-modal-inner">'
+					+ '<p style="color:#cc0000;font-size:12px;">' + escHtml( err.message || 'Something went wrong.' ) + '</p>'
+					+ '<div style="margin-top:8px;display:flex;gap:8px;">'
+					+ '<button type="button" id="scos-ca-back" class="scos-ca-modal-back">&larr; Back to Topics</button>'
+					+ '<button type="button" id="scos-ca-modal-close" class="button">Close</button>'
+					+ '</div></div>';
+				var backBtn  = document.getElementById( 'scos-ca-back' );
+				var closeBtn = document.getElementById( 'scos-ca-modal-close' );
+				if ( backBtn ) backBtn.addEventListener( 'click', function () { renderStep1( state.step1Results ); } );
+				if ( closeBtn ) closeBtn.addEventListener( 'click', closeModal );
+				console.error( '[scos-ca-suggest step2]', err );
+			} );
+	}
+
+	// -------------------------------------------------------------------------
+	// Entry point
+	// -------------------------------------------------------------------------
+
+	btn.addEventListener( 'click', fetchStep1 );
 
 	// -------------------------------------------------------------------------
 	// Utility
@@ -195,7 +354,7 @@
 
 	function escHtml( str ) {
 		var d = document.createElement( 'div' );
-		d.appendChild( document.createTextNode( str ) );
+		d.appendChild( document.createTextNode( String( str ) ) );
 		return d.innerHTML;
 	}
 

--- a/site-essentials/Modules/ContentArchitecture/views/meta-box.php
+++ b/site-essentials/Modules/ContentArchitecture/views/meta-box.php
@@ -332,7 +332,7 @@ $purpose_type_labels = [
 			<?php if ( class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) : ?>
 			<div class="scos-ca-suggest-wrap">
 				<button type="button" id="scos-ca-suggest-btn" class="button">
-					<?php esc_html_e( 'Suggest Intent Goal', 'site-essentials' ); ?>
+					<?php esc_html_e( 'Suggest with AI', 'site-essentials' ); ?>
 				</button>
 				<span class="scos-ca-suggest-spinner spinner" style="float:none;vertical-align:middle;margin-left:4px;"></span>
 				<p class="scos-ca-suggest-error" id="scos-ca-suggest-error" style="display:none;color:#cc0000;font-size:12px;margin:4px 0 0;"></p>


### PR DESCRIPTION
New ability: scos/suggest-topics
- Fetches all scos_topic terms server-side (top 100 by usage count)
- Passes <available_topics> (id: name pairs) + post content to AI
- Includes <current_topic> when already assigned (reassessment context)
- Validates returned term_ids against fetched term map (no hallucinated IDs)
- Output: { suggestions: [{ term_id, name, confidence: high/medium/low, topic_coverage }] }
- mcp.public: true, show_in_rest: true

Updated: scos/suggest-intent-goal
- Adds topic_term_id + existing_intent_goal to input schema
- Injects <topic> tag when term_id resolves to a valid scos_topic term
- Server-side reassessment: looks up existing FAQ link or freetext goal, injects as <current_intent_goal> in prompt
- Updated system instruction with topic scoping + reassessment rules

Meta_Box.php v1.5
- Loads Suggest_Topics.php alongside CA_Suggest.php
- Computes current topic in enqueue_assets() via wp_get_post_terms()
- Passes endpointTopics, endpointIntentGoal, currentTopicId, currentTopicName to JS

scos-ca-suggest.js v2.0 — full rewrite
- Two-step state machine: topics first, intent goals second
- Step 1: POST suggest-topics, render topic pills with confidence badges + coverage
- Click pill: fills #scos_ca_topic select, fetches step 2 scoped to selected topic
- Step 2: POST suggest-intent-goal, render intent goal pills
- Back button restores step 1 from cache (no second API call)
- Step 2 fill paths A/B/C preserved unchanged

UI: button label -> Suggest with AI, new CSS for step header, confidence badges (high/medium/low), coverage text, back button