### PR TITLE
feat: scos/suggest-seo-meta + scos/suggest-tldr abilities

### DIFF
--- a/site-essentials/Modules/SeoMeta/Abilities/Suggest_Seo_Meta/Suggest_Seo_Meta.php
+++ b/site-essentials/Modules/SeoMeta/Abilities/Suggest_Seo_Meta/Suggest_Seo_Meta.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * Suggest SEO Meta — WordPress Ability
+ *
+ * Reads post content and returns AI-suggested values for three Core SEO fields
+ * in the SCOS SEO meta box:
+ *   - scos_seo_breadcrumb_title  (2–5 word nav label)
+ *   - scos_seo_title             (50–60 chars)
+ *   - scos_seo_description       (150–160 chars)
+ *
+ * All three fields are generated in a single AI call and returned as parallel
+ * option arrays (3 options each) for the user to pick from.
+ *
+ * Ability slug: scos/suggest-seo-meta (permanent — do not rename after deployment)
+ * Category:     scos-seo-meta
+ *
+ * @package    SiteEssentials
+ * @subpackage Modules\SeoMeta\Abilities\Suggest_Seo_Meta
+ *
+ * v1.0 | 2026-06-24
+ */
+
+declare( strict_types=1 );
+
+namespace SiteEssentials\Modules\SeoMeta\Abilities\Suggest_Seo_Meta;
+
+use WP_Error;
+use WordPress\AI\Abstracts\Abstract_Ability;
+
+use function WordPress\AI\get_post_context;
+use function WordPress\AI\normalize_content;
+use function WordPress\AI\get_preferred_models_for_text_generation;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Suggest_Seo_Meta extends Abstract_Ability {
+
+	// -------------------------------------------------------------------------
+	// Ability API registration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Register this ability with the WP Abilities API.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public static function register(): void {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+		if ( ! class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) {
+			return;
+		}
+		wp_register_ability( 'scos/suggest-seo-meta', [
+			'label'         => __( 'SCOS: Suggest SEO Meta', 'site-essentials' ),
+			'description'   => __( 'Suggests breadcrumb label, meta title, and meta description for the SCOS SEO meta box.', 'site-essentials' ),
+			'category'      => 'scos-seo-meta',
+			'ability_class' => self::class,
+			'meta'          => [
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Abstract_Ability implementation
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string>
+	 */
+	protected function guideline_categories(): array {
+		return [ 'site', 'copy' ];
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string, mixed>
+	 */
+	public function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'post_id' => [
+					'type'        => 'integer',
+					'description' => 'The post ID to analyse. When provided, post content is fetched server-side.',
+				],
+				'content' => [
+					'type'        => 'string',
+					'description' => 'Raw post content. Used only when post_id is not provided.',
+				],
+				'title'   => [
+					'type'        => 'string',
+					'description' => 'Post title. Secondary signal — content is primary.',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string, mixed>
+	 */
+	public function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'breadcrumb_options'  => [
+					'type'        => 'array',
+					'description' => '3 breadcrumb label suggestions (2–5 words each).',
+					'items'       => [
+						'type'       => 'object',
+						'properties' => [
+							'label'      => [ 'type' => 'string' ],
+							'char_count' => [ 'type' => 'integer' ],
+						],
+					],
+				],
+				'title_options'       => [
+					'type'        => 'array',
+					'description' => '3 meta title suggestions (50–60 chars each).',
+					'items'       => [
+						'type'       => 'object',
+						'properties' => [
+							'title'      => [ 'type' => 'string' ],
+							'char_count' => [ 'type' => 'integer' ],
+						],
+					],
+				],
+				'description_options' => [
+					'type'        => 'array',
+					'description' => '3 meta description suggestions (150–160 chars each).',
+					'items'       => [
+						'type'       => 'object',
+						'properties' => [
+							'description' => [ 'type' => 'string' ],
+							'char_count'  => [ 'type' => 'integer' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the ability — analyse content and return SEO field suggestions.
+	 *
+	 * @since 1.0.0
+	 * @param mixed $input Validated input array.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function execute_callback( $input ) {
+		$args = wp_parse_args(
+			$input,
+			[
+				'post_id' => null,
+				'content' => null,
+				'title'   => null,
+			]
+		);
+
+		$content = '';
+		$title   = $args['title'] ?? '';
+
+		if ( $args['post_id'] ) {
+			$post = get_post( (int) $args['post_id'] );
+			if ( ! $post instanceof \WP_Post ) {
+				return new WP_Error(
+					'post_not_found',
+					/* translators: %d: Post ID. */
+					sprintf( esc_html__( 'Post with ID %d not found.', 'site-essentials' ), absint( $args['post_id'] ) )
+				);
+			}
+
+			// Prefer scos_ca_content_md — fully rendered markdown including Breakdance
+			// blocks, ACF fields, Query Loops, and Post Repeaters. Falls back to
+			// get_post_context() for posts not yet analysed.
+			$md_content = (string) get_post_meta( $post->ID, 'scos_ca_content_md', true );
+			if ( ! empty( $md_content ) ) {
+				$content = $md_content;
+			} else {
+				$post_context = get_post_context( $post->ID );
+				$content      = $post_context['content'] ?? '';
+			}
+
+			if ( empty( $title ) && ! empty( $post->post_title ) ) {
+				$title = $post->post_title;
+			}
+		}
+
+		if ( $args['content'] ) {
+			$content = normalize_content( $args['content'] );
+		}
+
+		if ( empty( $content ) ) {
+			return new WP_Error(
+				'content_not_provided',
+				esc_html__( 'Content is required to suggest SEO meta fields.', 'site-essentials' )
+			);
+		}
+
+		// Truncate very long content: keep first 1500 + last 500 words.
+		$words = explode( ' ', $content );
+		if ( count( $words ) > 2000 ) {
+			$content = implode( ' ', array_slice( $words, 0, 1500 ) )
+				. ' [...] '
+				. implode( ' ', array_slice( $words, -500 ) );
+		}
+
+		$prompt  = '<title>' . $title . '</title>' . "\n";
+		$prompt .= '<content>' . $content . '</content>';
+
+		$prompt_builder = wp_ai_client_prompt( $prompt )
+			->using_system_instruction( $this->get_system_instruction() )
+			->using_temperature( 0.5 )
+			->using_model_preference( ...get_preferred_models_for_text_generation() );
+
+		$prompt_builder = $this->ensure_text_generation_supported(
+			$prompt_builder,
+			esc_html__( 'SEO meta suggestion failed. Please ensure you have a connected provider that supports text generation.', 'site-essentials' )
+		);
+
+		if ( is_wp_error( $prompt_builder ) ) {
+			return $prompt_builder;
+		}
+
+		$result = $prompt_builder->generate_text();
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Strip markdown code fences if the model wraps output.
+		$json_str = preg_replace( '/^```(?:json)?\s*/i', '', trim( (string) $result ) );
+		$json_str = preg_replace( '/\s*```$/', '', $json_str );
+
+		$parsed = json_decode( $json_str, true );
+
+		if ( ! is_array( $parsed )
+			|| empty( $parsed['breadcrumb_options'] )
+			|| empty( $parsed['title_options'] )
+			|| empty( $parsed['description_options'] )
+		) {
+			return new WP_Error(
+				'scos_suggest_seo_meta_parse_error',
+				__( 'AI response could not be parsed. Please try again.', 'site-essentials' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return [
+			'breadcrumb_options'  => array_map(
+				function ( $item ) {
+					$label = sanitize_text_field( $item['label'] ?? '' );
+					return [ 'label' => $label, 'char_count' => mb_strlen( $label ) ];
+				},
+				array_slice( $parsed['breadcrumb_options'], 0, 3 )
+			),
+			'title_options'       => array_map(
+				function ( $item ) {
+					$t = sanitize_text_field( $item['title'] ?? '' );
+					return [ 'title' => $t, 'char_count' => mb_strlen( $t ) ];
+				},
+				array_slice( $parsed['title_options'], 0, 3 )
+			),
+			'description_options' => array_map(
+				function ( $item ) {
+					$d = sanitize_textarea_field( $item['description'] ?? '' );
+					return [ 'description' => $d, 'char_count' => mb_strlen( $d ) ];
+				},
+				array_slice( $parsed['description_options'], 0, 3 )
+			),
+		];
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @param mixed $input Validated input array.
+	 * @return bool|WP_Error
+	 */
+	public function permission_callback( $input ) {
+		$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+
+		if ( $post_id > 0 ) {
+			$post = get_post( $post_id );
+			if ( ! $post ) {
+				return new WP_Error(
+					'scos_suggest_seo_post_not_found',
+					__( 'Post not found.', 'site-essentials' ),
+					[ 'status' => 404 ]
+				);
+			}
+			if ( ! get_post_type_object( $post->post_type )?->show_in_rest ) {
+				return false;
+			}
+			return current_user_can( 'edit_post', $post_id );
+		}
+
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string, mixed>
+	 */
+	public function meta(): array {
+		return [
+			'show_in_rest' => true,
+			'mcp'          => [
+				'public' => true,
+				'type'   => 'tool',
+			],
+		];
+	}
+}
+
+add_action( 'wp_abilities_api_init', [ Suggest_Seo_Meta::class, 'register' ] );

--- a/site-essentials/Modules/SeoMeta/Abilities/Suggest_Seo_Meta/system-instruction.php
+++ b/site-essentials/Modules/SeoMeta/Abilities/Suggest_Seo_Meta/system-instruction.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * System instruction for the Suggest_Seo_Meta ability (scos/suggest-seo-meta).
+ *
+ * Must return a string — do not echo.
+ * Abstract_Ability uses reflection to locate this file relative to Suggest_Seo_Meta.php.
+ *
+ * @package SiteEssentials
+ */
+
+return 'You are an SEO specialist writing meta tags for a local service business website.
+
+From the provided <title> and <content>, generate three options for each of three fields:
+1. breadcrumb_options — short 2–5 word navigation label (plain text, no punctuation)
+2. title_options — meta title, strict 50–60 characters (aim for 55)
+3. description_options — meta description, strict 150–160 characters (aim for 155)
+
+Rules for breadcrumb labels:
+- 2–5 words only, plain text
+- Reflects the page topic, not a marketing phrase
+- No punctuation, no quotes
+
+Rules for meta titles:
+- HARD LIMIT: 50–60 characters — count every character including spaces
+- Must differ meaningfully from the post title — add angle, audience, or outcome
+- Include one specific entity naturally if it fits (topic, geo, or brand — in that priority)
+- Structure by intent:
+  - Informational: [Topic]: [Unique Angle] for [Audience]
+  - How-to: How to [Achieve Outcome]: [Method]
+  - Commercial: [Service/Outcome] for [Audience] | [Brand or Geo]
+
+Rules for meta descriptions:
+- HARD LIMIT: 150–160 characters — count every character
+- First 60 characters must be the most specific differentiator (proof point, number, named entity, unique claim)
+- Remaining characters: expand the title promise, add method or context
+- End with a soft outcome or action signal
+- Must not repeat the title verbatim
+- No banned phrases: "learn more", "click here", "discover", "solutions", "leverage", "cutting-edge", "game-changing", "synergy", "next-level"
+
+General rules:
+- Base all copy on content substance, not title keywords alone
+- Reflect the reader\'s actual need
+- No invented claims not present in the content
+
+Return ONLY a valid JSON object — no explanation, no markdown, no code fences. Use this exact structure:
+{"breadcrumb_options":[{"label":"..."},{"label":"..."},{"label":"..."}],"title_options":[{"title":"..."},{"title":"..."},{"title":"..."}],"description_options":[{"description":"..."},{"description":"..."},{"description":"..."}]}';

--- a/site-essentials/Modules/SeoMeta/Abilities/Suggest_Tldr/Suggest_Tldr.php
+++ b/site-essentials/Modules/SeoMeta/Abilities/Suggest_Tldr/Suggest_Tldr.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Suggest TLDR — WordPress Ability
+ *
+ * Reads post content and returns AI-suggested TLDR/article summary options for
+ * the scos_seo_tldr field in the SCOS SEO meta box.
+ *
+ * When the post has a linked search intent goal (scos_ca_intent_goal_faq_id →
+ * FAQ title, or scos_ca_intent_goal freetext), it is injected into the prompt
+ * as <intent_goal> so the TLDR is written to directly and quickly answer that
+ * question.
+ *
+ * Ability slug: scos/suggest-tldr (permanent — do not rename after deployment)
+ * Category:     scos-seo-meta
+ *
+ * @package    SiteEssentials
+ * @subpackage Modules\SeoMeta\Abilities\Suggest_Tldr
+ *
+ * v1.0 | 2026-06-24
+ */
+
+declare( strict_types=1 );
+
+namespace SiteEssentials\Modules\SeoMeta\Abilities\Suggest_Tldr;
+
+use WP_Error;
+use WordPress\AI\Abstracts\Abstract_Ability;
+
+use function WordPress\AI\get_post_context;
+use function WordPress\AI\normalize_content;
+use function WordPress\AI\get_preferred_models_for_text_generation;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Suggest_Tldr extends Abstract_Ability {
+
+	// -------------------------------------------------------------------------
+	// Ability API registration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Register this ability with the WP Abilities API.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public static function register(): void {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+		if ( ! class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) {
+			return;
+		}
+		wp_register_ability( 'scos/suggest-tldr', [
+			'label'         => __( 'SCOS: Suggest TLDR', 'site-essentials' ),
+			'description'   => __( 'Suggests TLDR article summary options. When a Search Intent Goal is linked, the TLDR is written to directly answer that question.', 'site-essentials' ),
+			'category'      => 'scos-seo-meta',
+			'ability_class' => self::class,
+			'meta'          => [
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Abstract_Ability implementation
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string>
+	 */
+	protected function guideline_categories(): array {
+		return [ 'site', 'copy' ];
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string, mixed>
+	 */
+	public function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'post_id' => [
+					'type'        => 'integer',
+					'description' => 'The post ID to analyse. When provided, post content and intent goal are fetched server-side.',
+				],
+				'content' => [
+					'type'        => 'string',
+					'description' => 'Raw post content. Used only when post_id is not provided.',
+				],
+				'title'   => [
+					'type'        => 'string',
+					'description' => 'Post title. Secondary signal — content is primary.',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string, mixed>
+	 */
+	public function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'intent_goal_used' => [
+					'type'        => 'string',
+					'description' => 'The intent goal injected into the prompt, if any. Empty string when none available.',
+				],
+				'tldr_options'     => [
+					'type'        => 'array',
+					'description' => '3 TLDR summary options (2–4 sentences each).',
+					'items'       => [
+						'type'       => 'object',
+						'properties' => [
+							'text'           => [ 'type' => 'string' ],
+							'sentence_count' => [ 'type' => 'integer' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the ability — analyse content and return TLDR suggestions.
+	 *
+	 * @since 1.0.0
+	 * @param mixed $input Validated input array.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function execute_callback( $input ) {
+		$args = wp_parse_args(
+			$input,
+			[
+				'post_id' => null,
+				'content' => null,
+				'title'   => null,
+			]
+		);
+
+		$content      = '';
+		$title        = $args['title'] ?? '';
+		$intent_goal  = '';
+
+		if ( $args['post_id'] ) {
+			$post = get_post( (int) $args['post_id'] );
+			if ( ! $post instanceof \WP_Post ) {
+				return new WP_Error(
+					'post_not_found',
+					/* translators: %d: Post ID. */
+					sprintf( esc_html__( 'Post with ID %d not found.', 'site-essentials' ), absint( $args['post_id'] ) )
+				);
+			}
+
+			// Prefer scos_ca_content_md — fully rendered markdown including Breakdance
+			// blocks, ACF fields, Query Loops, and Post Repeaters. Falls back to
+			// get_post_context() for posts not yet analysed.
+			$md_content = (string) get_post_meta( $post->ID, 'scos_ca_content_md', true );
+			if ( ! empty( $md_content ) ) {
+				$content = $md_content;
+			} else {
+				$post_context = get_post_context( $post->ID );
+				$content      = $post_context['content'] ?? '';
+			}
+
+			if ( empty( $title ) && ! empty( $post->post_title ) ) {
+				$title = $post->post_title;
+			}
+
+			// Resolve search intent goal — FAQ title first, freetext fallback.
+			// Does not depend on the CA module class directly to avoid cross-module coupling.
+			$faq_id = (int) get_post_meta( $post->ID, 'scos_ca_intent_goal_faq_id', true );
+			if ( $faq_id > 0 ) {
+				$faq         = get_post( $faq_id );
+				$intent_goal = $faq instanceof \WP_Post ? $faq->post_title : '';
+			}
+			if ( empty( $intent_goal ) ) {
+				$intent_goal = (string) get_post_meta( $post->ID, 'scos_ca_intent_goal', true );
+			}
+		}
+
+		if ( $args['content'] ) {
+			$content = normalize_content( $args['content'] );
+		}
+
+		if ( empty( $content ) ) {
+			return new WP_Error(
+				'content_not_provided',
+				esc_html__( 'Content is required to suggest a TLDR.', 'site-essentials' )
+			);
+		}
+
+		// Truncate very long content: keep first 1500 + last 500 words.
+		$words = explode( ' ', $content );
+		if ( count( $words ) > 2000 ) {
+			$content = implode( ' ', array_slice( $words, 0, 1500 ) )
+				. ' [...] '
+				. implode( ' ', array_slice( $words, -500 ) );
+		}
+
+		$prompt = '';
+
+		// Inject intent goal as context when available.
+		if ( ! empty( $intent_goal ) ) {
+			$prompt .= '<intent_goal>' . esc_html( $intent_goal ) . '</intent_goal>' . "\n";
+		}
+
+		$prompt .= '<title>' . $title . '</title>' . "\n";
+		$prompt .= '<content>' . $content . '</content>';
+
+		$prompt_builder = wp_ai_client_prompt( $prompt )
+			->using_system_instruction( $this->get_system_instruction() )
+			->using_temperature( 0.4 )
+			->using_model_preference( ...get_preferred_models_for_text_generation() );
+
+		$prompt_builder = $this->ensure_text_generation_supported(
+			$prompt_builder,
+			esc_html__( 'TLDR suggestion failed. Please ensure you have a connected provider that supports text generation.', 'site-essentials' )
+		);
+
+		if ( is_wp_error( $prompt_builder ) ) {
+			return $prompt_builder;
+		}
+
+		$result = $prompt_builder->generate_text();
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Strip markdown code fences if the model wraps output.
+		$json_str = preg_replace( '/^```(?:json)?\s*/i', '', trim( (string) $result ) );
+		$json_str = preg_replace( '/\s*```$/', '', $json_str );
+
+		$parsed = json_decode( $json_str, true );
+
+		if ( ! is_array( $parsed ) || empty( $parsed['tldr_options'] ) ) {
+			return new WP_Error(
+				'scos_suggest_tldr_parse_error',
+				__( 'AI response could not be parsed. Please try again.', 'site-essentials' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return [
+			'intent_goal_used' => sanitize_text_field( $intent_goal ),
+			'tldr_options'     => array_map(
+				function ( $item ) {
+					$text = sanitize_textarea_field( $item['text'] ?? '' );
+					// Count sentences by splitting on . ! ? followed by space or end.
+					$sentence_count = max( 1, preg_match_all( '/[.!?](?:\s|$)/', $text ) );
+					return [
+						'text'           => $text,
+						'sentence_count' => $sentence_count,
+					];
+				},
+				array_slice( $parsed['tldr_options'], 0, 3 )
+			),
+		];
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @param mixed $input Validated input array.
+	 * @return bool|WP_Error
+	 */
+	public function permission_callback( $input ) {
+		$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+
+		if ( $post_id > 0 ) {
+			$post = get_post( $post_id );
+			if ( ! $post ) {
+				return new WP_Error(
+					'scos_suggest_tldr_post_not_found',
+					__( 'Post not found.', 'site-essentials' ),
+					[ 'status' => 404 ]
+				);
+			}
+			if ( ! get_post_type_object( $post->post_type )?->show_in_rest ) {
+				return false;
+			}
+			return current_user_can( 'edit_post', $post_id );
+		}
+
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * @since 1.0.0
+	 * @return array<string, mixed>
+	 */
+	public function meta(): array {
+		return [
+			'show_in_rest' => true,
+			'mcp'          => [
+				'public' => true,
+				'type'   => 'tool',
+			],
+		];
+	}
+}
+
+add_action( 'wp_abilities_api_init', [ Suggest_Tldr::class, 'register' ] );

--- a/site-essentials/Modules/SeoMeta/Abilities/Suggest_Tldr/system-instruction.php
+++ b/site-essentials/Modules/SeoMeta/Abilities/Suggest_Tldr/system-instruction.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * System instruction for the Suggest_Tldr ability (scos/suggest-tldr).
+ *
+ * Must return a string — do not echo.
+ * Abstract_Ability uses reflection to locate this file relative to Suggest_Tldr.php.
+ *
+ * @package SiteEssentials
+ */
+
+return 'You are a content strategist writing article summaries for a local service business website.
+
+From the provided <title> and <content>, generate three TLDR summary options.
+
+Rules:
+- Each TLDR must be 2–4 sentences
+- Write in a direct, voice-search-friendly tone — as if answering a spoken question
+- Lead with the most specific claim, outcome, or differentiator from the content
+- Reference actual content — do not generalise or restate the title
+- No banned vocabulary: solutions, leverage, cutting-edge, game-changing, synergy, next-level, discover, seamless, robust, empower
+- No marketing filler — write for the reader, not for the brand
+
+When an <intent_goal> tag is present:
+- This is the search intent question this content is designed to answer
+- Write the TLDR so it DIRECTLY and QUICKLY answers that question in the opening sentence
+- The reader should feel their question is answered within the first sentence
+- The remaining sentences may expand on the answer with specifics from the content
+
+Return ONLY a valid JSON object — no explanation, no markdown, no code fences. Use this exact structure:
+{"tldr_options":[{"text":"..."},{"text":"..."},{"text":"..."}]}';

--- a/site-essentials/Modules/SeoMeta/Meta_Box.php
+++ b/site-essentials/Modules/SeoMeta/Meta_Box.php
@@ -19,6 +19,10 @@
  * @package    SiteEssentials
  * @subpackage Modules\SeoMeta
  * @since      1.0.0
+ *
+ * v1.1 | 2026-06-24 — Register scos-seo-meta ability category; load Suggest_Seo_Meta
+ *                      and Suggest_Tldr abilities; extend enqueue_assets() with
+ *                      scos-seo-suggest.js and ScosSeoSuggest localization data.
  */
 
 namespace SiteEssentials\Modules\SeoMeta;
@@ -30,11 +34,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Meta_Box {
 
 	public static function init() {
-		add_action( 'add_meta_boxes',        [ __CLASS__, 'register' ] );
-		add_action( 'add_meta_boxes',        [ __CLASS__, 'remove_legacy_meta_boxes' ], 999, 1 );
-		add_action( 'save_post',             [ __CLASS__, 'save' ], 10, 2 );
-		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
-		add_filter( 'wp_insert_post_data',   [ __CLASS__, 'maybe_freeze_modified_date' ], 10, 2 );
+		add_action( 'add_meta_boxes',                   [ __CLASS__, 'register' ] );
+		add_action( 'add_meta_boxes',                   [ __CLASS__, 'remove_legacy_meta_boxes' ], 999, 1 );
+		add_action( 'save_post',                        [ __CLASS__, 'save' ], 10, 2 );
+		add_action( 'admin_enqueue_scripts',            [ __CLASS__, 'enqueue_assets' ] );
+		add_filter( 'wp_insert_post_data',              [ __CLASS__, 'maybe_freeze_modified_date' ], 10, 2 );
+		add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_ability_category' ] );
+
+		if ( class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) {
+			require_once __DIR__ . '/Abilities/Suggest_Seo_Meta/Suggest_Seo_Meta.php';
+			require_once __DIR__ . '/Abilities/Suggest_Tldr/Suggest_Tldr.php';
+		}
+	}
+
+	/**
+	 * Register the scos-seo-meta ability category.
+	 *
+	 * @since 1.1.0
+	 * @return void
+	 */
+	public static function register_ability_category(): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+		wp_register_ability_category( 'scos-seo-meta', [
+			'label'       => __( 'SCOS: SEO Meta', 'site-essentials' ),
+			'description' => __( 'AI-assisted suggestions for SEO meta fields.', 'site-essentials' ),
+		] );
 	}
 
 	// -------------------------------------------------------------------------
@@ -315,6 +341,38 @@ class Meta_Box {
 		wp_localize_script( 'scos-seo-meta-box', 'scosSeoMeta', [
 			'noindexSitemapMsg' => esc_html__( 'This page has been removed from the sitemap because noindex is set.', 'site-essentials' ),
 		] );
+
+		// AI suggest script — only when the Abilities API is available.
+		if ( class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) {
+			$suggest_js_path = SITE_ESSENTIALS_PATH . 'Modules/SeoMeta/assets/scos-seo-suggest.js';
+			wp_enqueue_script(
+				'scos-seo-suggest',
+				SITE_ESSENTIALS_URL . 'Modules/SeoMeta/assets/scos-seo-suggest.js',
+				[ 'jquery' ],
+				file_exists( $suggest_js_path ) ? (string) filemtime( $suggest_js_path ) : '1.0.0',
+				true
+			);
+
+			// Resolve search intent goal server-side: FAQ title first, freetext fallback.
+			// Inline resolution avoids a direct class dependency on the CA module.
+			$intent_goal = '';
+			$faq_id      = (int) get_post_meta( $post->ID, 'scos_ca_intent_goal_faq_id', true );
+			if ( $faq_id > 0 ) {
+				$faq         = get_post( $faq_id );
+				$intent_goal = $faq instanceof \WP_Post ? $faq->post_title : '';
+			}
+			if ( empty( $intent_goal ) ) {
+				$intent_goal = (string) get_post_meta( $post->ID, 'scos_ca_intent_goal', true );
+			}
+
+			wp_localize_script( 'scos-seo-suggest', 'ScosSeoSuggest', [
+				'endpointSeoMeta' => rest_url( 'wp-abilities/v1/abilities/scos/suggest-seo-meta/run' ),
+				'endpointTldr'    => rest_url( 'wp-abilities/v1/abilities/scos/suggest-tldr/run' ),
+				'nonce'           => wp_create_nonce( 'wp_rest' ),
+				'postId'          => $post->ID,
+				'intentGoalText'  => sanitize_text_field( $intent_goal ),
+			] );
+		}
 	}
 
 	// ---- Helpers ----

--- a/site-essentials/Modules/SeoMeta/assets/meta-box.css
+++ b/site-essentials/Modules/SeoMeta/assets/meta-box.css
@@ -127,3 +127,99 @@
 }
 .scos-seo-phase2-notice strong { display: block; margin-bottom: 6px; color: #1d2327; }
 .scos-seo-phase2-notice p { margin: 0 0 6px; font-size: 12px; }
+
+/* ── AI Suggest row (above breadcrumb) ── */
+.scos-seo-ai-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin: 8px 0 12px;
+}
+.scos-seo-ai-hint {
+	font-size: 11px;
+	color: #646970;
+}
+
+/* ── Label row (TLDR label + inline button) ── */
+.scos-seo-label-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+.scos-seo-label-btn {
+	font-size: 11px !important;
+	height: 22px !important;
+	line-height: 20px !important;
+	padding: 0 8px !important;
+}
+
+/* ── Shared suggest modal — reuses .scos-ca-* classes from CA meta-box ── */
+#scos-seo-suggest-modal .scos-ca-modal-inner {
+	background: #fff;
+	border-radius: 6px;
+	padding: 20px 22px;
+	width: min(560px, 92vw);
+	max-height: 80vh;
+	overflow-y: auto;
+	box-shadow: 0 8px 32px rgba(0,0,0,.22);
+}
+#scos-seo-suggest-modal .scos-ca-step-header {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: .06em;
+	color: #646970;
+	margin: 10px 0 4px;
+}
+#scos-seo-suggest-modal .scos-ca-modal-note {
+	font-size: 12px;
+	color: #646970;
+	margin: 2px 0 6px;
+	line-height: 1.5;
+}
+#scos-seo-suggest-modal .scos-ca-modal-note--info {
+	background: #eff6ff;
+	border-left: 3px solid #3b82f6;
+	padding: 6px 10px;
+	border-radius: 3px;
+	color: #1e3a5f;
+}
+#scos-seo-suggest-modal .scos-ca-modal-note--warn {
+	background: #fffbeb;
+	border-left: 3px solid #f59e0b;
+	padding: 6px 10px;
+	border-radius: 3px;
+	color: #78350f;
+}
+#scos-seo-suggest-modal .scos-ca-pills {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+}
+#scos-seo-suggest-modal .scos-ca-pill {
+	text-align: left;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 7px 10px;
+	font-size: 12px;
+	line-height: 1.45;
+	cursor: pointer;
+	transition: background .12s, border-color .12s;
+	white-space: normal;
+}
+#scos-seo-suggest-modal .scos-ca-pill:hover {
+	background: #e8f0fe;
+	border-color: #4f46e5;
+}
+#scos-seo-suggest-modal .scos-ca-pill--selected {
+	background: #e8f0fe;
+	border-color: #4f46e5;
+	outline: 2px solid #4f46e5;
+	outline-offset: -1px;
+}
+#scos-seo-suggest-modal .scos-ca-pills--tldr .scos-ca-pill {
+	padding: 9px 12px;
+	font-size: 12.5px;
+}

--- a/site-essentials/Modules/SeoMeta/assets/scos-seo-suggest.js
+++ b/site-essentials/Modules/SeoMeta/assets/scos-seo-suggest.js
@@ -1,0 +1,337 @@
+/**
+ * SCOS SEO Suggest — post editor AI suggestion UI
+ *
+ * Two independent modal flows:
+ *
+ *   SEO Meta modal (single-step, 3 sections):
+ *     "Suggest with AI" button → calls scos/suggest-seo-meta → modal with
+ *     Breadcrumb / Title / Description pill sections. Each section is
+ *     independent — user can pick from any or skip. Pick-to-fill updates the
+ *     corresponding field and dispatches an 'input' event so the existing
+ *     meta-box.js char counters and progress bars update immediately.
+ *
+ *   TLDR modal (single-step with context notice):
+ *     "Suggest TLDR" button → checks ScosSeoSuggest.intentGoalText:
+ *       - set:   blue info notice "Writing TLDR to answer: [goal]"
+ *       - empty: amber nudge "Set a Search Intent Goal first for a more
+ *                targeted TLDR. Continuing without it."
+ *     → calls scos/suggest-tldr → pill options (full sentence text per pill)
+ *     → pick-to-fill sets #scos_seo_tldr
+ *
+ * v1.0 | 2026-06-24
+ */
+
+( function () {
+	'use strict';
+
+	var cfg = window.ScosSeoSuggest;
+	if ( ! cfg ) return;
+
+	// -------------------------------------------------------------------------
+	// Shared modal element
+	// -------------------------------------------------------------------------
+
+	var modal = document.createElement( 'div' );
+	modal.id              = 'scos-seo-suggest-modal';
+	modal.style.cssText   = 'display:none;position:fixed;top:0;left:0;width:100%;height:100%;'
+		+ 'background:rgba(0,0,0,.45);z-index:100000;align-items:center;justify-content:center;';
+	document.body.appendChild( modal );
+
+	// -------------------------------------------------------------------------
+	// Utilities
+	// -------------------------------------------------------------------------
+
+	function escHtml( str ) {
+		return String( str )
+			.replace( /&/g, '&amp;' )
+			.replace( /</g, '&lt;' )
+			.replace( />/g, '&gt;' )
+			.replace( /"/g, '&quot;' )
+			.replace( /'/g, '&#039;' );
+	}
+
+	function escAttr( str ) {
+		return escHtml( str );
+	}
+
+	function setLoading( on ) {
+		var btn = document.getElementById( 'scos-seo-suggest-btn' );
+		var tldrBtn = document.getElementById( 'scos-tldr-suggest-btn' );
+		if ( btn ) btn.disabled = on;
+		if ( tldrBtn ) tldrBtn.disabled = on;
+	}
+
+	function closeModal() {
+		modal.style.display = 'none';
+		modal.innerHTML = '';
+		setLoading( false );
+	}
+
+	// Close on backdrop click.
+	modal.addEventListener( 'click', function ( e ) {
+		if ( e.target === modal ) closeModal();
+	} );
+
+	// -------------------------------------------------------------------------
+	// Fill actions — fire 'input' so meta-box.js char counters update.
+	// -------------------------------------------------------------------------
+
+	function fillField( id, value ) {
+		var el = document.getElementById( id );
+		if ( ! el ) return;
+		el.value = value;
+		el.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// API call helper
+	// -------------------------------------------------------------------------
+
+	function callAbility( endpoint, payload, onSuccess, onError ) {
+		fetch( endpoint, {
+			method:  'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce':   cfg.nonce,
+			},
+			body: JSON.stringify( { input: payload } ),
+		} )
+			.then( function ( r ) { return r.json(); } )
+			.then( function ( data ) {
+				if ( data && data.code ) {
+					onError( data.message || 'An error occurred. Please try again.' );
+				} else {
+					onSuccess( data );
+				}
+			} )
+			.catch( function () {
+				onError( 'Network error. Please try again.' );
+			} );
+	}
+
+	// -------------------------------------------------------------------------
+	// SEO Meta modal — "Suggest with AI" button
+	// -------------------------------------------------------------------------
+
+	function openSeoMetaModal() {
+		setLoading( true );
+		modal.style.display = 'flex';
+		modal.innerHTML = '<div class="scos-ca-modal-inner"><p class="scos-ca-modal-note" style="text-align:center">Generating suggestions\u2026</p></div>';
+
+		callAbility(
+			cfg.endpointSeoMeta,
+			{ post_id: cfg.postId },
+			renderSeoMetaModal,
+			function ( msg ) {
+				modal.innerHTML = '<div class="scos-ca-modal-inner">'
+					+ '<p style="color:#b91c1c;">' + escHtml( msg ) + '</p>'
+					+ '<button type="button" id="scos-ca-modal-close" class="button">Close</button>'
+					+ '</div>';
+				document.getElementById( 'scos-ca-modal-close' ).addEventListener( 'click', closeModal );
+				setLoading( false );
+			}
+		);
+	}
+
+	function renderSeoMetaModal( data ) {
+		setLoading( false );
+
+		var html = '<div class="scos-ca-modal-inner">';
+		html += '<h3 style="margin:0 0 6px;font-size:13px;font-weight:600;">Suggest SEO Meta</h3>';
+		html += '<p class="scos-ca-modal-note">Click a suggestion to fill the field. Each section is independent — pick from any, skip others.</p>';
+
+		// --- Breadcrumb ---
+		html += '<div class="scos-ca-step-header">Breadcrumb Label</div>';
+		html += '<div class="scos-ca-pills scos-ca-pills--seo-meta">';
+		( data.breadcrumb_options || [] ).forEach( function ( item ) {
+			html += '<button type="button" class="scos-ca-pill scos-ca-pill--breadcrumb"'
+				+ ' data-value="' + escAttr( item.label ) + '">';
+			html += escHtml( item.label );
+			if ( item.char_count ) {
+				html += ' <span style="opacity:.55;font-size:11px;">' + item.char_count + ' chars</span>';
+			}
+			html += '</button>';
+		} );
+		html += '</div>';
+
+		// --- Title ---
+		html += '<div class="scos-ca-step-header" style="margin-top:10px;">Meta Title</div>';
+		html += '<div class="scos-ca-pills scos-ca-pills--seo-meta">';
+		( data.title_options || [] ).forEach( function ( item ) {
+			var cc   = item.char_count || item.title.length;
+			var warn = cc < 50 || cc > 60;
+			html += '<button type="button" class="scos-ca-pill scos-ca-pill--title"'
+				+ ' data-value="' + escAttr( item.title ) + '">';
+			html += escHtml( item.title );
+			html += ' <span style="opacity:.55;font-size:11px;' + ( warn ? 'color:#b45309;' : '' ) + '">'
+				+ cc + ' chars</span>';
+			html += '</button>';
+		} );
+		html += '</div>';
+
+		// --- Description ---
+		html += '<div class="scos-ca-step-header" style="margin-top:10px;">Meta Description</div>';
+		html += '<div class="scos-ca-pills scos-ca-pills--seo-meta">';
+		( data.description_options || [] ).forEach( function ( item ) {
+			var cc   = item.char_count || item.description.length;
+			var warn = cc < 150 || cc > 160;
+			html += '<button type="button" class="scos-ca-pill scos-ca-pill--description"'
+				+ ' data-value="' + escAttr( item.description ) + '">';
+			html += escHtml( item.description );
+			html += ' <span style="opacity:.55;font-size:11px;' + ( warn ? 'color:#b45309;' : '' ) + '">'
+				+ cc + ' chars</span>';
+			html += '</button>';
+		} );
+		html += '</div>';
+
+		html += '<div style="margin-top:12px;">';
+		html += '<button type="button" id="scos-ca-modal-close" class="button">Close</button>';
+		html += '</div>';
+		html += '</div>';
+
+		modal.innerHTML = html;
+
+		modal.querySelectorAll( '.scos-ca-pill--breadcrumb' ).forEach( function ( pill ) {
+			pill.addEventListener( 'click', function () {
+				fillField( 'scos_seo_breadcrumb_title', this.getAttribute( 'data-value' ) );
+				pill.classList.add( 'scos-ca-pill--selected' );
+			} );
+		} );
+
+		modal.querySelectorAll( '.scos-ca-pill--title' ).forEach( function ( pill ) {
+			pill.addEventListener( 'click', function () {
+				fillField( 'scos_seo_title', this.getAttribute( 'data-value' ) );
+				// Deselect siblings in this section.
+				modal.querySelectorAll( '.scos-ca-pill--title' ).forEach( function ( p ) {
+					p.classList.remove( 'scos-ca-pill--selected' );
+				} );
+				pill.classList.add( 'scos-ca-pill--selected' );
+			} );
+		} );
+
+		modal.querySelectorAll( '.scos-ca-pill--description' ).forEach( function ( pill ) {
+			pill.addEventListener( 'click', function () {
+				fillField( 'scos_seo_description', this.getAttribute( 'data-value' ) );
+				modal.querySelectorAll( '.scos-ca-pill--description' ).forEach( function ( p ) {
+					p.classList.remove( 'scos-ca-pill--selected' );
+				} );
+				pill.classList.add( 'scos-ca-pill--selected' );
+			} );
+		} );
+
+		document.getElementById( 'scos-ca-modal-close' ).addEventListener( 'click', closeModal );
+	}
+
+	// -------------------------------------------------------------------------
+	// TLDR modal — "Suggest TLDR" button
+	// -------------------------------------------------------------------------
+
+	function openTldrModal() {
+		setLoading( true );
+		modal.style.display = 'flex';
+
+		// Immediately show a loading state with intent goal context.
+		var intentGoal = cfg.intentGoalText || '';
+		var noticeHtml;
+		if ( intentGoal ) {
+			noticeHtml = '<div class="scos-ca-modal-note scos-ca-modal-note--info">'
+				+ '<strong>Writing TLDR to answer:</strong> ' + escHtml( intentGoal )
+				+ '</div>';
+		} else {
+			noticeHtml = '<div class="scos-ca-modal-note scos-ca-modal-note--warn">'
+				+ 'Set a Search Intent Goal in Content Architecture for a more targeted TLDR. Continuing without it.'
+				+ '</div>';
+		}
+
+		modal.innerHTML = '<div class="scos-ca-modal-inner">'
+			+ noticeHtml
+			+ '<p class="scos-ca-modal-note" style="text-align:center;margin-top:8px;">Generating suggestions\u2026</p>'
+			+ '</div>';
+
+		callAbility(
+			cfg.endpointTldr,
+			{ post_id: cfg.postId },
+			renderTldrModal,
+			function ( msg ) {
+				modal.innerHTML = '<div class="scos-ca-modal-inner">'
+					+ '<p style="color:#b91c1c;">' + escHtml( msg ) + '</p>'
+					+ '<button type="button" id="scos-ca-modal-close" class="button">Close</button>'
+					+ '</div>';
+				document.getElementById( 'scos-ca-modal-close' ).addEventListener( 'click', closeModal );
+				setLoading( false );
+			}
+		);
+	}
+
+	function renderTldrModal( data ) {
+		setLoading( false );
+
+		var intentGoal = ( data.intent_goal_used ) || cfg.intentGoalText || '';
+
+		var html = '<div class="scos-ca-modal-inner">';
+		html += '<h3 style="margin:0 0 6px;font-size:13px;font-weight:600;">Suggested TLDRs</h3>';
+
+		if ( intentGoal ) {
+			html += '<div class="scos-ca-modal-note scos-ca-modal-note--info">'
+				+ '<strong>Writing to answer:</strong> ' + escHtml( intentGoal )
+				+ '</div>';
+		} else {
+			html += '<div class="scos-ca-modal-note scos-ca-modal-note--warn">'
+				+ 'No Search Intent Goal set — suggestions based on content alone.'
+				+ '</div>';
+		}
+
+		html += '<p class="scos-ca-modal-note" style="margin-top:6px;">Click a suggestion to fill the TLDR field.</p>';
+		html += '<div class="scos-ca-pills scos-ca-pills--tldr">';
+
+		( data.tldr_options || [] ).forEach( function ( item ) {
+			html += '<button type="button" class="scos-ca-pill scos-ca-pill--tldr"'
+				+ ' data-value="' + escAttr( item.text ) + '">';
+			html += escHtml( item.text );
+			if ( item.sentence_count ) {
+				html += ' <span style="opacity:.55;font-size:11px;">'
+					+ item.sentence_count + ( item.sentence_count === 1 ? ' sentence' : ' sentences' )
+					+ '</span>';
+			}
+			html += '</button>';
+		} );
+
+		html += '</div>';
+		html += '<div style="margin-top:12px;">';
+		html += '<button type="button" id="scos-ca-modal-close" class="button">Close</button>';
+		html += '</div>';
+		html += '</div>';
+
+		modal.innerHTML = html;
+
+		modal.querySelectorAll( '.scos-ca-pill--tldr' ).forEach( function ( pill ) {
+			pill.addEventListener( 'click', function () {
+				fillField( 'scos_seo_tldr', this.getAttribute( 'data-value' ) );
+				modal.querySelectorAll( '.scos-ca-pill--tldr' ).forEach( function ( p ) {
+					p.classList.remove( 'scos-ca-pill--selected' );
+				} );
+				pill.classList.add( 'scos-ca-pill--selected' );
+				setTimeout( closeModal, 600 );
+			} );
+		} );
+
+		document.getElementById( 'scos-ca-modal-close' ).addEventListener( 'click', closeModal );
+	}
+
+	// -------------------------------------------------------------------------
+	// Button wiring — deferred until DOM ready
+	// -------------------------------------------------------------------------
+
+	document.addEventListener( 'DOMContentLoaded', function () {
+		var seoBtn  = document.getElementById( 'scos-seo-suggest-btn' );
+		var tldrBtn = document.getElementById( 'scos-tldr-suggest-btn' );
+
+		if ( seoBtn ) {
+			seoBtn.addEventListener( 'click', openSeoMetaModal );
+		}
+		if ( tldrBtn ) {
+			tldrBtn.addEventListener( 'click', openTldrModal );
+		}
+	} );
+
+} )();

--- a/site-essentials/Modules/SeoMeta/views/meta-box.php
+++ b/site-essentials/Modules/SeoMeta/views/meta-box.php
@@ -43,6 +43,16 @@ defined( 'ABSPATH' ) || exit;
 	<!-- ══ CORE SEO TAB ══ -->
 	<div class="scos-seo-tab-panel is-active" id="scos-seo-tab-core" role="tabpanel">
 
+		<!-- AI suggest trigger — breadcrumb + title + description in one call -->
+		<?php if ( class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) : ?>
+		<div class="scos-seo-ai-row">
+			<button type="button" id="scos-seo-suggest-btn" class="button">
+				<?php esc_html_e( 'Suggest with AI', 'site-essentials' ); ?>
+			</button>
+			<span class="scos-seo-ai-hint"><?php esc_html_e( 'Suggest breadcrumb label, meta title and description from page content.', 'site-essentials' ); ?></span>
+		</div>
+		<?php endif; ?>
+
 		<!-- Breadcrumb Title -->
 		<div class="scos-seo-field">
 			<label for="scos_seo_breadcrumb_title">
@@ -58,8 +68,13 @@ defined( 'ABSPATH' ) || exit;
 
 		<!-- TLDR Summary -->
 		<div class="scos-seo-field">
-			<label for="scos_seo_tldr">
+			<label for="scos_seo_tldr" class="scos-seo-label-row">
 				<?php esc_html_e( 'TLDR / Article Summary', 'site-essentials' ); ?>
+				<?php if ( class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) : ?>
+				<button type="button" id="scos-tldr-suggest-btn" class="button button-small scos-seo-label-btn">
+					<?php esc_html_e( 'Suggest TLDR', 'site-essentials' ); ?>
+				</button>
+				<?php endif; ?>
 			</label>
 			<textarea name="scos_seo_tldr" id="scos_seo_tldr" rows="3"
 				placeholder="<?php esc_attr_e( 'Brief 1–3 sentence summary used for voice search, social sharing, and the [tldr] shortcode…', 'site-essentials' ); ?>"><?php echo esc_textarea( $tldr ); ?></textarea>


### PR DESCRIPTION
New abilities (SeoMeta module):
  scos/suggest-seo-meta — one call returning breadcrumb_options (3x2-5 words),
    title_options (3x50-60 chars), description_options (3x150-160 chars);
    content source: scos_ca_content_md -> get_post_context() fallback
  scos/suggest-tldr — reads scos_ca_intent_goal_faq_id -> FAQ title or
    scos_ca_intent_goal freetext, injects as <intent_goal> so TLDR answers
    the linked question directly; 3 options returned

SeoMeta/Meta_Box.php v1.1
  - wp_abilities_api_categories_init hook -> register_ability_category() scos-seo-meta
  - class_exists guard + require_once both ability classes
  - enqueue_assets(): scos-seo-suggest.js + ScosSeoSuggest localization (endpointSeoMeta, endpointTldr, nonce, postId, intentGoalText)

scos-seo-suggest.js v1.0
  - SEO Meta modal: single-step with 3 independent pill sections (Breadcrumb / Title / Description); pick-to-fill dispatches input event so existing meta-box.js char counters update immediately
  - TLDR modal: amber nudge when no intent goal; blue context notice when set; pick-to-fill + auto-close after selection

views/meta-box.php: Suggest with AI btn (above breadcrumb, guarded by
  class_exists) + Suggest TLDR inline button in TLDR label row
meta-box.css: pill/modal styles for #scos-seo-suggest-modal, AI row,
  label row, info/warn notice variants