### PR TITLE
feat: CA Suggest checks existing FAQs before generating new ones

### DIFF
--- a/site-essentials/Modules/ContentArchitecture/Abilities/CA_Suggest/CA_Suggest.php
+++ b/site-essentials/Modules/ContentArchitecture/Abilities/CA_Suggest/CA_Suggest.php
@@ -14,6 +14,7 @@
  * v1.1 | 2026-06-23
  * v1.2 | 2026-06-24 — Add topic_term_id + existing_intent_goal to input schema; inject <topic> and reassessment context into prompt.
  * v1.3 | 2026-06-24 — Prefer scos_ca_content_md (Breakdance + ACF rendered content) over raw post_content.
+ * v1.4 | 2026-06-30 — Query existing FAQs and inject into prompt for deduplication; parse matched_faq from AI response.
  */
 
 declare( strict_types=1 );
@@ -22,6 +23,7 @@ namespace SiteEssentials\Modules\ContentArchitecture\Abilities\CA_Suggest;
 
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
+use SiteEssentials\Modules\ContentArchitecture\Intent_Goal_Resolver;
 
 use function WordPress\AI\get_post_context;
 use function WordPress\AI\normalize_content;
@@ -126,6 +128,20 @@ class CA_Suggest extends Abstract_Ability {
 		return [
 			'type'       => 'object',
 			'properties' => [
+				'matched_faq'  => [
+					'type'        => 'object',
+					'description' => 'An existing FAQ that matches or closely matches the content\'s search intent. Omitted when no match is found.',
+					'properties'  => [
+						'faq_id'        => [ 'type' => 'integer', 'description' => 'FAQ post ID.' ],
+						'match_quality' => [ 'type' => 'string', 'description' => '"good" = usable as-is. "close" = matches but could be improved.' ],
+						'suggested_edit' => [ 'type' => 'string', 'description' => 'Improved title when match_quality is "close". Null otherwise.' ],
+						'title'         => [ 'type' => 'string', 'description' => 'Existing FAQ title.' ],
+						'status'        => [ 'type' => 'string', 'description' => 'Post status.' ],
+						'topic'         => [ 'type' => 'string', 'description' => 'Assigned topic name.' ],
+						'edit_url'      => [ 'type' => 'string', 'description' => 'Admin edit URL for the FAQ.' ],
+						'incomplete'    => [ 'type' => 'boolean', 'description' => 'True when the FAQ has no answer yet.' ],
+					],
+				],
 				'intent_goals' => [
 					'type'        => 'array',
 					'description' => 'Suggested search intent goal statements, ordered by confidence.',
@@ -214,11 +230,12 @@ class CA_Suggest extends Abstract_Ability {
 				. implode( ' ', array_slice( $words, -500 ) );
 		}
 
-		$prompt = '';
+		$topic_term_id = (int) ( $args['topic_term_id'] ?? 0 );
+		$prompt        = '';
 
 		// Topic scoping context — when a topic is selected, scope the intent goal to it.
-		if ( ! empty( $args['topic_term_id'] ) ) {
-			$topic_term = get_term( (int) $args['topic_term_id'], 'scos_topic' );
+		if ( $topic_term_id > 0 ) {
+			$topic_term = get_term( $topic_term_id, 'scos_topic' );
 			if ( $topic_term && ! is_wp_error( $topic_term ) ) {
 				$prompt .= '<topic>' . esc_html( $topic_term->name ) . '</topic>' . "\n";
 			}
@@ -229,8 +246,8 @@ class CA_Suggest extends Abstract_Ability {
 		if ( $args['post_id'] ) {
 			$existing_faq_id = (int) get_post_meta( (int) $args['post_id'], 'scos_ca_intent_goal_faq_id', true );
 			if ( $existing_faq_id > 0 ) {
-				$existing_faq          = get_post( $existing_faq_id );
-				$current_intent_goal   = $existing_faq ? $existing_faq->post_title : '';
+				$existing_faq        = get_post( $existing_faq_id );
+				$current_intent_goal = $existing_faq ? $existing_faq->post_title : '';
 			}
 			if ( empty( $current_intent_goal ) ) {
 				$current_intent_goal = (string) get_post_meta( (int) $args['post_id'], 'scos_ca_intent_goal', true );
@@ -241,6 +258,12 @@ class CA_Suggest extends Abstract_Ability {
 		}
 		if ( ! empty( $current_intent_goal ) ) {
 			$prompt .= '<current_intent_goal>' . esc_html( $current_intent_goal ) . '</current_intent_goal>' . "\n";
+		}
+
+		// Existing FAQs — inject for deduplication check.
+		$existing_faqs_text = $this->get_existing_faqs_for_prompt( $topic_term_id );
+		if ( ! empty( $existing_faqs_text ) ) {
+			$prompt .= "<existing_faqs>\n" . $existing_faqs_text . "\n</existing_faqs>\n";
 		}
 
 		$prompt .= '<title>' . $title . '</title>' . "\n";
@@ -272,7 +295,7 @@ class CA_Suggest extends Abstract_Ability {
 
 		$parsed = json_decode( $json_str, true );
 
-		if ( ! is_array( $parsed ) || empty( $parsed['intent_goals'] ) ) {
+		if ( ! is_array( $parsed ) ) {
 			return new WP_Error(
 				'scos_suggest_parse_error',
 				__( 'AI response could not be parsed. Please try again.', 'site-essentials' ),
@@ -280,8 +303,30 @@ class CA_Suggest extends Abstract_Ability {
 			);
 		}
 
-		return [
-			'intent_goals' => array_map(
+		// Resolve matched_faq — validate the returned ID against the actual FAQ library.
+		$matched_faq = null;
+		if ( ! empty( $parsed['matched_faq'] ) && is_array( $parsed['matched_faq'] ) ) {
+			$matched_faq_id = (int) ( $parsed['matched_faq']['faq_id'] ?? 0 );
+			if ( $matched_faq_id > 0 ) {
+				$summary = Intent_Goal_Resolver::get_faq_summary( $matched_faq_id );
+				if ( $summary ) {
+					$matched_faq = array_merge(
+						$summary,
+						[
+							'match_quality'  => in_array( $parsed['matched_faq']['match_quality'] ?? '', [ 'good', 'close' ], true )
+								? $parsed['matched_faq']['match_quality']
+								: 'good',
+							'suggested_edit' => ! empty( $parsed['matched_faq']['suggested_edit'] )
+								? sanitize_text_field( (string) $parsed['matched_faq']['suggested_edit'] )
+								: null,
+						]
+					);
+				}
+			}
+		}
+
+		$intent_goals = ! empty( $parsed['intent_goals'] ) && is_array( $parsed['intent_goals'] )
+			? array_map(
 				function ( $item ) {
 					return [
 						'goal'       => sanitize_text_field( $item['goal'] ?? '' ),
@@ -289,8 +334,23 @@ class CA_Suggest extends Abstract_Ability {
 					];
 				},
 				$parsed['intent_goals']
-			),
-		];
+			)
+			: [];
+
+		if ( empty( $intent_goals ) && ! $matched_faq ) {
+			return new WP_Error(
+				'scos_suggest_parse_error',
+				__( 'AI response could not be parsed. Please try again.', 'site-essentials' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$response = [ 'intent_goals' => $intent_goals ];
+		if ( $matched_faq ) {
+			$response['matched_faq'] = $matched_faq;
+		}
+
+		return $response;
 	}
 
 	/**
@@ -340,6 +400,82 @@ class CA_Suggest extends Abstract_Ability {
 	// -------------------------------------------------------------------------
 	// Private helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Build the <existing_faqs> prompt block for deduplication checking.
+	 *
+	 * Returns up to 30 FAQs tagged with the selected topic first, then up
+	 * to 20 more from other topics / no topic. Titles only — no content.
+	 * Returns an empty string when the FAQ library is empty.
+	 *
+	 * @param int $topic_term_id Selected scos_topic term ID, or 0.
+	 * @return string Ready-to-inject prompt block, or empty string.
+	 */
+	private function get_existing_faqs_for_prompt( int $topic_term_id ): string {
+		$lines    = [];
+		$seen_ids = [];
+
+		// Topic-matched FAQs first so the AI finds the best match early.
+		if ( $topic_term_id > 0 ) {
+			$topic_faqs = get_posts(
+				[
+					'post_type'      => 'faq',
+					'post_status'    => [ 'publish', 'draft' ],
+					'posts_per_page' => 30,
+					'no_found_rows'  => true,
+					'orderby'        => 'title',
+					'order'          => 'ASC',
+					'tax_query'      => [
+						[
+							'taxonomy' => 'scos_topic',
+							'field'    => 'term_id',
+							'terms'    => $topic_term_id,
+						],
+					],
+				]
+			);
+			if ( $topic_faqs ) {
+				$lines[] = '[Matching topic]';
+				foreach ( $topic_faqs as $faq ) {
+					$lines[]    = $faq->ID . ': ' . $faq->post_title;
+					$seen_ids[] = $faq->ID;
+				}
+			}
+		}
+
+		// All remaining FAQs — different topics or none assigned.
+		$other_args = [
+			'post_type'      => 'faq',
+			'post_status'    => [ 'publish', 'draft' ],
+			'posts_per_page' => 20,
+			'no_found_rows'  => true,
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+		];
+		if ( ! empty( $seen_ids ) ) {
+			$other_args['post__not_in'] = $seen_ids;
+		}
+		$other_faqs = get_posts( $other_args );
+		if ( $other_faqs ) {
+			$lines[] = $topic_term_id > 0 ? '[Other topics / no topic]' : '[All FAQs]';
+			foreach ( $other_faqs as $faq ) {
+				$lines[] = $faq->ID . ': ' . $faq->post_title;
+			}
+		}
+
+		// Only 2 lines means only section headers — no actual FAQs.
+		if ( count( $lines ) <= ( $topic_term_id > 0 ? 1 : 1 ) ) {
+			return '';
+		}
+
+		// Need at least one actual FAQ line (not just headers).
+		$faq_lines = array_filter( $lines, fn( $l ) => false !== strpos( $l, ': ' ) );
+		if ( empty( $faq_lines ) ) {
+			return '';
+		}
+
+		return implode( "\n", $lines );
+	}
 
 }
 

--- a/site-essentials/Modules/ContentArchitecture/Abilities/CA_Suggest/system-instruction.php
+++ b/site-essentials/Modules/ContentArchitecture/Abilities/CA_Suggest/system-instruction.php
@@ -6,19 +6,53 @@
  * Abstract_Ability uses reflection to locate this file relative to CA_Suggest.php.
  *
  * @package SiteEssentials
+ *
+ * v1.1 | 2026-06-30 — FAQ match check; specificity rules to avoid over-niche phrasing.
  */
 
 return 'You are a content strategist analysing web content for a local service business website.
 
-Identify the search intent goal — the single most important question this content answers for a reader. Provide exactly 3 alternative phrasings as separate suggestions, ordered by confidence from highest to lowest. Each should be a plain-language question or goal statement (e.g. "How do solar panels work for off-grid homes?" or "Find a steel fabricator in Ballarat").
+Your job has two parts: (1) check whether an existing FAQ already answers this content\'s search intent, and (2) suggest new intent goal phrasings as alternatives.
 
-Rules:
+## Part 1 — Match check (only when <existing_faqs> is provided)
+
+Scan the FAQ list for one that already addresses the same underlying question this content answers. Match on intent, not wording.
+
+Match quality:
+- "good" — the FAQ accurately captures this content\'s primary intent and can be used as-is
+- "close" — the FAQ covers the same question but could be improved (too generic, could add a key modifier the content explicitly supports, or awkward phrasing); provide a suggested_edit with a cleaner title
+- No match — omit matched_faq entirely; do not force a match
+
+Only return one match (the best one). Check topic-match FAQs first.
+
+## Part 2 — Intent goal suggestions
+
+Identify the single most important question this content answers for a reader. Provide exactly 3 alternative phrasings ordered by confidence from highest to lowest.
+
+Specificity rules:
+- Write at the topic level — questions must be broadly reusable, not tied to one scenario or audience persona
+  - Good: "How do QR codes reduce customer support calls?"
+  - Bad: "How do QR codes reduce support calls for a BNB rental owner and improve the guests experience?"
+- Include location modifiers ONLY when the content explicitly and repeatedly targets a specific location (e.g. a page about "Ballarat SEO services" can say "Ballarat"; a general explainer about Google rankings should not)
+- Include service or business-type modifiers only when the content is exclusively about that niche — use generic terms ("small business", "service business") not specific roles
 - Base intent on content substance, not title keywords
 - Reflect the reader\'s actual underlying question, not the content\'s marketing angle
-- Keep suggestions conversational and specific
 - Do not invent information not in the content
-- When a <topic> tag is present: scope all 3 suggestions specifically to that topic perspective — the intent goal should reflect how the content serves readers interested in that topic
-- When a <current_intent_goal> tag is present: this is a reassessment of an existing assignment. Acknowledge what was previously set. Evaluate whether it still accurately reflects the content\'s primary question — it may remain correct, but do not default to validating it
 
-Return ONLY a valid JSON object — no explanation, no markdown, no code fences. Use this exact structure:
+Context tags:
+- <topic>: scope all 3 suggestions and the match check to that topic perspective
+- <current_intent_goal>: this is a reassessment — evaluate whether it still fits; it may be correct, but do not default to validating it
+- <existing_faqs>: list of existing FAQ IDs and titles to check before suggesting new ones
+
+## Output format
+
+Return ONLY a valid JSON object — no explanation, no markdown, no code fences.
+
+When a match is found:
+{"matched_faq":{"faq_id":123,"match_quality":"good","suggested_edit":null},"intent_goals":[{"goal":"...","confidence":0.9},{"goal":"...","confidence":0.75},{"goal":"...","confidence":0.6}]}
+
+For a close match with an edit suggestion:
+{"matched_faq":{"faq_id":456,"match_quality":"close","suggested_edit":"Improved question wording here"},"intent_goals":[{"goal":"...","confidence":0.9},{"goal":"...","confidence":0.75},{"goal":"...","confidence":0.6}]}
+
+When no match is found:
 {"intent_goals":[{"goal":"...","confidence":0.9},{"goal":"...","confidence":0.75},{"goal":"...","confidence":0.6}]}';

--- a/site-essentials/Modules/ContentArchitecture/assets/meta-box.css
+++ b/site-essentials/Modules/ContentArchitecture/assets/meta-box.css
@@ -636,6 +636,56 @@
 	margin-left: 2px;
 }
 
+/* ═══════════════ MATCHED FAQ PANEL ═══════════════ */
+
+.scos-ca-match-found {
+	border-radius: 4px;
+	padding: 10px 12px;
+	margin-bottom: 12px;
+}
+
+.scos-ca-match-found--good {
+	background: #d1fae5;
+}
+
+.scos-ca-match-found--close {
+	background: #fef3c7;
+}
+
+.scos-ca-match-found__label {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: .04em;
+	margin-bottom: 4px;
+}
+
+.scos-ca-match-found--good .scos-ca-match-found__label {
+	color: #065f46;
+}
+
+.scos-ca-match-found--close .scos-ca-match-found__label {
+	color: #92400e;
+}
+
+.scos-ca-match-found__title {
+	font-size: 13px;
+	font-weight: 500;
+	margin-bottom: 4px;
+}
+
+.scos-ca-match-found__edit {
+	font-size: 12px;
+	color: var(--scos-ink-muted, #666);
+	margin-bottom: 8px;
+}
+
+.scos-ca-match-found__actions {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+}
+
 /* ═══════════════ BACK BUTTON ═══════════════ */
 
 .scos-ca-modal-back {

--- a/site-essentials/Modules/ContentArchitecture/assets/meta-box.js
+++ b/site-essentials/Modules/ContentArchitecture/assets/meta-box.js
@@ -378,6 +378,13 @@
 			);
 		});
 
+		// Allow scos-ca-suggest.js to link an existing FAQ via custom event.
+		document.addEventListener( 'scos:selectFaq', function ( e ) {
+			if ( e.detail && e.detail.id ) {
+				selectFaq( e.detail );
+			}
+		} );
+
 	} // end if faqModuleActive
 
 }(jQuery));

--- a/site-essentials/Modules/ContentArchitecture/assets/scos-ca-suggest.js
+++ b/site-essentials/Modules/ContentArchitecture/assets/scos-ca-suggest.js
@@ -17,6 +17,7 @@
  *
  * v2.0 | 2026-06-24
  * v2.1 | 2026-06-24 — Path C now shows suggestions and replaces linked FAQ.
+ * v2.2 | 2026-06-30 — Show matched_faq panel in step 2; dispatch scos:selectFaq to link existing FAQ.
  */
 
 ( function () {
@@ -232,10 +233,10 @@
 	}
 
 	// -------------------------------------------------------------------------
-	// Step 2 render — Intent Goal suggestions
+	// Step 2 render — Intent Goal suggestions (+ optional matched FAQ)
 	// -------------------------------------------------------------------------
 
-	function renderStep2( goals ) {
+	function renderStep2( goals, matchedFaq ) {
 		state.step = 2;
 		var path   = detectFillPath();
 
@@ -245,23 +246,51 @@
 		html += '<div class="scos-ca-step-header">Step 2 of 2 &mdash; Intent Goal'
 			+ ( topicLabel ? ' <span style="opacity:.7;">(scoped to: ' + escHtml( topicLabel ) + ')</span>' : '' )
 			+ '</div>';
-		html += '<h3 style="margin:4px 0 4px;font-size:13px;font-weight:600;">Suggested Intent Goals</h3>';
 
-		if ( path === 'faq-linked' ) {
-			html += '<p class="scos-ca-modal-note">An FAQ is already linked. Picking a suggestion will remove it and replace with a new FAQ.</p>';
-		} else {
-			html += '<p class="scos-ca-modal-note">Click a suggestion to fill the field. Save the post to keep changes.</p>';
+		// ── Matched FAQ panel ─────────────────────────────────────────────
+		if ( matchedFaq ) {
+			var isGood  = matchedFaq.match_quality === 'good';
+			var modCls  = isGood ? 'scos-ca-match-found--good' : 'scos-ca-match-found--close';
+			var matchLabel = isGood ? '&#10003; Existing FAQ matches' : '&#126; Similar FAQ found';
+
+			html += '<div class="scos-ca-match-found ' + modCls + '">';
+			html += '<div class="scos-ca-match-found__label">' + matchLabel + '</div>';
+			html += '<div class="scos-ca-match-found__title">' + escHtml( matchedFaq.title ) + '</div>';
+			if ( matchedFaq.suggested_edit ) {
+				html += '<div class="scos-ca-match-found__edit">Suggested edit: <em>' + escHtml( matchedFaq.suggested_edit ) + '</em></div>';
+			}
+			html += '<div class="scos-ca-match-found__actions">';
+			html += '<button type="button" class="button button-primary" id="scos-ca-link-existing-faq">Link this FAQ</button>';
+			html += '<a href="' + escAttr( matchedFaq.edit_url || '' ) + '" target="_blank" rel="noopener" class="button">Edit FAQ &#8599;</a>';
+			html += '</div>';
+			html += '</div>';
 		}
-		html += '<div class="scos-ca-pills">';
-		goals.forEach( function ( item ) {
-			var pct = Math.round( ( item.confidence || 0 ) * 100 );
-			html += '<button type="button" class="scos-ca-pill scos-ca-pill--goal"'
-				+ ' data-goal="' + escAttr( item.goal ) + '">';
-			html += escHtml( item.goal );
-			if ( pct > 0 ) html += ' <span style="opacity:.6;font-size:11px;">(' + pct + '%)</span>';
-			html += '</button>';
-		} );
-		html += '</div>';
+
+		// ── New suggestions ───────────────────────────────────────────────
+		if ( goals.length ) {
+			html += '<h3 style="margin:8px 0 4px;font-size:13px;font-weight:600;">'
+				+ ( matchedFaq ? 'Or create a new FAQ:' : 'Suggested Intent Goals' )
+				+ '</h3>';
+
+			if ( ! matchedFaq ) {
+				if ( path === 'faq-linked' ) {
+					html += '<p class="scos-ca-modal-note">An FAQ is already linked. Picking a suggestion will remove it and replace with a new FAQ.</p>';
+				} else {
+					html += '<p class="scos-ca-modal-note">Click a suggestion to fill the field. Save the post to keep changes.</p>';
+				}
+			}
+
+			html += '<div class="scos-ca-pills">';
+			goals.forEach( function ( item ) {
+				var pct = Math.round( ( item.confidence || 0 ) * 100 );
+				html += '<button type="button" class="scos-ca-pill scos-ca-pill--goal"'
+					+ ' data-goal="' + escAttr( item.goal ) + '">';
+				html += escHtml( item.goal );
+				if ( pct > 0 ) html += ' <span style="opacity:.6;font-size:11px;">(' + pct + '%)</span>';
+				html += '</button>';
+			} );
+			html += '</div>';
+		}
 
 		html += '<div style="margin-top:12px;display:flex;gap:8px;align-items:center;">';
 		html += '<button type="button" id="scos-ca-back" class="scos-ca-modal-back">&larr; Back to Topics</button>';
@@ -270,6 +299,15 @@
 		html += '</div>';
 
 		modal.innerHTML = html;
+
+		// "Link this FAQ" — dispatch to meta-box.js via custom event.
+		var linkBtn = document.getElementById( 'scos-ca-link-existing-faq' );
+		if ( linkBtn && matchedFaq ) {
+			linkBtn.addEventListener( 'click', function () {
+				document.dispatchEvent( new CustomEvent( 'scos:selectFaq', { detail: matchedFaq } ) );
+				closeModal();
+			} );
+		}
 
 		modal.querySelectorAll( '.scos-ca-pill--goal' ).forEach( function ( pill ) {
 			pill.addEventListener( 'click', function () {
@@ -287,7 +325,6 @@
 		var backBtn = document.getElementById( 'scos-ca-back' );
 		if ( backBtn ) {
 			backBtn.addEventListener( 'click', function () {
-				// Restore step 1 from cache — no second API call.
 				if ( state.step1Results ) {
 					renderStep1( state.step1Results );
 				} else {
@@ -344,14 +381,14 @@
 			},
 		} )
 			.then( function ( data ) {
-				var goals = data.intent_goals || [];
-				if ( ! goals.length ) {
+				var goals      = data.intent_goals || [];
+				var matchedFaq = data.matched_faq || null;
+				if ( ! goals.length && ! matchedFaq ) {
 					throw new Error( 'No intent goal suggestions returned. Please try again.' );
 				}
-				renderStep2( goals );
+				renderStep2( goals, matchedFaq );
 			} )
 			.catch( function ( err ) {
-				// On step 2 failure, show error inside modal with back button.
 				modal.innerHTML = '<div class="scos-ca-modal-inner">'
 					+ '<p style="color:#cc0000;font-size:12px;">' + escHtml( err.message || 'Something went wrong.' ) + '</p>'
 					+ '<div style="margin-top:8px;display:flex;gap:8px;">'


### PR DESCRIPTION
Inject up to 50 existing FAQ titles into the AI prompt (topic-matched first, then others) so the model can find a match before generating new ones. AI returns matched_faq with match_quality good or close; close matches include a suggested_edit for the existing title.
Server validates matched_faq.faq_id via Intent_Goal_Resolver (hallucinated IDs are silently dropped). Step 2 modal shows green/amber match panel above new suggestions. Link this FAQ dispatches scos:selectFaq to meta-box.js. System instruction rewritten with specificity rules to prevent over-niche phrasing - location and service modifiers only when content supports them.