### PR TITLE
Fix WP-CLI permission error and enable rich text for TLDR field

### DIFF
--- a/brighter-core/includes/social-amplification/class-airtable-helper.php
+++ b/brighter-core/includes/social-amplification/class-airtable-helper.php
@@ -11,6 +11,8 @@
  *
  * v1.0 | original
  * v1.1 | 2026-06-29 — Read scos_seo_tldr + scos_sa_shortlink_slug first; bw_ keys as fallback only.
+ * v1.2 | 2026-07-17 — Strip HTML from TLDR before sending to Airtable (field now supports
+ *                      bold/lists/links via wp_editor()).
  */
 
 if (!defined('ABSPATH')) exit;
@@ -341,9 +343,12 @@ class BW_Airtable_Helper {
             // Taxonomy/Category
             'Category' => wp_get_post_categories($post_id, array('fields' => 'names'))[0] ?? '',
             
-            // Content fields
-            'TLDR' => get_post_meta($post_id, 'scos_seo_tldr', true)
-                   ?: get_post_meta($post_id, 'bw_tldr', true), // TODO: remove bw_ fallback once all sites resaved
+            // Content fields — TLDR may contain basic HTML (bold/lists/links) since it's
+            // edited via a rich-text field; Airtable's TLDR column is plain text, so strip tags.
+            'TLDR' => wp_strip_all_tags(
+                (string) ( get_post_meta($post_id, 'scos_seo_tldr', true)
+                    ?: get_post_meta($post_id, 'bw_tldr', true) ) // TODO: remove bw_ fallback once all sites resaved
+            ),
             'Excerpt' => $post->post_excerpt ?: wp_trim_words($post->post_content, 55, '...'),
             
             // ALTC Strategy fields - Linked Record when we have Airtable record IDs

--- a/brighter-core/includes/social-amplification/class-social-amplification-api.php
+++ b/brighter-core/includes/social-amplification/class-social-amplification-api.php
@@ -10,6 +10,8 @@
  *
  * v1.0 | original
  * v1.1 | 2026-06-29 — Read scos_seo_tldr + scos_sa_shortlink_slug first; bw_ keys as fallback only.
+ * v1.2 | 2026-07-17 — Strip HTML from TLDR reads (field now supports bold/lists/links
+ *                      via wp_editor(); this data feeds plain-text AI prompts/captions).
  */
 
 if (!defined('ABSPATH')) exit;
@@ -290,7 +292,9 @@ class BW_Social_Amplification_API {
         $content_type = BW_Content_Type_Helper::get_content_type($post_id, $post->post_type);
         $purpose = get_post_meta($post_id, 'scos_ca_purpose', true) ?: get_post_meta($post_id, 'bw_purpose', true) ?: '';
         $intent  = get_post_meta($post_id, 'scos_ca_intent',  true) ?: get_post_meta($post_id, 'bw_intent',  true) ?: '';
-        $tldr    = get_post_meta($post_id, 'scos_seo_tldr', true);
+        // TLDR may contain basic HTML (bold/lists/links) via wp_editor() — strip tags
+        // since this feeds AI prompts and social captions that expect plain text.
+        $tldr    = wp_strip_all_tags((string) get_post_meta($post_id, 'scos_seo_tldr', true));
         if (empty($tldr)) {
             $tldr = get_post_meta($post_id, 'bw_tldr', true); // TODO: remove fallback once all sites resaved
         }
@@ -552,8 +556,9 @@ class BW_Social_Amplification_API {
             return new WP_Error('invalid_post', 'Post not found', array('status' => 404));
         }
 
-        // Get post context
-        $tldr = get_post_meta($post_id, 'scos_seo_tldr', true);
+        // Get post context — strip tags: TLDR may contain basic HTML (bold/lists/links)
+        // via wp_editor(), but this feeds a plain-text prompt context.
+        $tldr = wp_strip_all_tags((string) get_post_meta($post_id, 'scos_seo_tldr', true));
         if (empty($tldr)) {
             $tldr = get_post_meta($post_id, 'bw_tldr', true); // TODO: remove fallback once all sites resaved
         }

--- a/brighter-core/includes/social-amplification/class-webhook-trigger.php
+++ b/brighter-core/includes/social-amplification/class-webhook-trigger.php
@@ -10,6 +10,8 @@
  *
  * v1.0 | original
  * v1.1 | 2026-06-29 — Read scos_seo_tldr first; bw_tldr as fallback only.
+ * v1.2 | 2026-07-17 — Strip HTML from TLDR read (field now supports bold/lists/links
+ *                      via wp_editor()).
  */
 
 if (!defined('ABSPATH')) exit;
@@ -214,7 +216,9 @@ class BW_Social_Webhook_Trigger {
     private function get_image_optimization_data($post_id) {
         // Get post content
         $post = get_post($post_id);
-        $tldr = get_post_meta($post_id, 'scos_seo_tldr', true);
+        // TLDR may contain basic HTML (bold/lists/links) via wp_editor() — strip tags,
+        // this feeds AI image-optimization prompt context which expects plain text.
+        $tldr = wp_strip_all_tags((string) get_post_meta($post_id, 'scos_seo_tldr', true));
         if (empty($tldr)) {
             $tldr = get_post_meta($post_id, 'bw_tldr', true); // TODO: remove fallback once all sites resaved
         }

--- a/site-essentials/Modules/ContentArchitecture/Content_Inventory_Gatherer.php
+++ b/site-essentials/Modules/ContentArchitecture/Content_Inventory_Gatherer.php
@@ -8,6 +8,8 @@
  * Performance: One server-side pass with batch meta loading, no N+1 queries.
  *
  * v1.0 | 2026-06-06
+ * v1.1 | 2026-07-17 — Strip HTML from scos_seo_tldr export (field now supports
+ *                      bold/lists/links via wp_editor(); baseline reports expect plain text).
  *
  * @package    SiteEssentials
  * @subpackage Modules\ContentArchitecture
@@ -276,7 +278,7 @@ class Content_Inventory_Gatherer {
 				// SEO Meta
 				'scos_seo_title'               => $nn( get_post_meta( $pid, 'scos_seo_title', true ) ),
 				'scos_seo_description'         => $nn( get_post_meta( $pid, 'scos_seo_description', true ) ),
-				'scos_seo_tldr'                => $nn( get_post_meta( $pid, 'scos_seo_tldr', true ) ),
+				'scos_seo_tldr'                => $nn( wp_strip_all_tags( (string) get_post_meta( $pid, 'scos_seo_tldr', true ) ) ),
 				'scos_seo_robots'              => $nn( get_post_meta( $pid, 'scos_seo_robots', true ) ),
 				'scos_seo_canonical'           => $nn( get_post_meta( $pid, 'scos_seo_canonical', true ) ),
 				'scos_seo_breadcrumb_title'    => $nn( get_post_meta( $pid, 'scos_seo_breadcrumb_title', true ) ),

--- a/site-essentials/Modules/SeoMeta/CLI/Fill_Image_Meta_Command.php
+++ b/site-essentials/Modules/SeoMeta/CLI/Fill_Image_Meta_Command.php
@@ -15,6 +15,8 @@
  *
  * v1.0 | 2026-07-01
  * v1.1 | 2026-07-02 — Use wp_get_ability()->execute() instead of direct instantiation.
+ * v1.2 | 2026-07-13 — Auto-establish a current-user context (WP-CLI defaults to user 0,
+ *                      which fails the ability's upload_files permission_callback).
  *
  * @package    SiteEssentials
  * @subpackage Modules\SeoMeta\CLI
@@ -55,6 +57,11 @@ class Fill_Image_Meta_Command extends WP_CLI_Command {
 	 * [--format=<format>]
 	 * : Output format: json (default) or table.
 	 *
+	 * [--user=<id|login|email>]
+	 * : WP-CLI global flag. Run as this user so the ability's permission_callback
+	 * (requires upload_files) resolves correctly. If omitted, the command falls
+	 * back to the site's first administrator automatically — see notes below.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Fill all images site-wide that are missing alt or title
@@ -82,6 +89,8 @@ class Fill_Image_Meta_Command extends WP_CLI_Command {
 		if ( ! class_exists( 'WordPress\AI\Abstracts\Abstract_Ability' ) ) {
 			WP_CLI::error( 'The WordPress AI plugin is not active. scos/fill-image-meta requires it.' );
 		}
+
+		$this->ensure_current_user_context();
 
 		$attachment_id = isset( $assoc_args['attachment-id'] ) ? absint( $assoc_args['attachment-id'] ) : 0;
 		$post_id       = isset( $assoc_args['post-id'] )       ? absint( $assoc_args['post-id'] )       : 0;
@@ -242,6 +251,53 @@ class Fill_Image_Meta_Command extends WP_CLI_Command {
 			$grand_processed,
 			$grand_skipped,
 			$grand_errors
+		) );
+	}
+
+	/**
+	 * Ensure a real user is set as the "current user" for this request.
+	 *
+	 * WP-CLI runs as user ID 0 (no authenticated user) unless the global
+	 * --user=<id|login|email> flag is passed. The scos/fill-image-meta ability's
+	 * permission_callback() requires current_user_can( 'upload_files' ), which
+	 * always fails for user 0 — this is what produces the
+	 * "does not have necessary permission" warning even though the AI provider
+	 * itself is correctly connected and approved.
+	 *
+	 * Shell/WP-CLI access to this command is already a privileged trust
+	 * boundary (server access or an authenticated MCP/automation caller), so
+	 * when no --user is supplied we fall back to the site's first
+	 * administrator rather than forcing every automated caller (Hermes, cron,
+	 * MCP tools) to know and pass an admin user ID.
+	 *
+	 * @since 1.2.0
+	 * @return void
+	 */
+	private function ensure_current_user_context(): void {
+		if ( get_current_user_id() > 0 ) {
+			// --user was already supplied and resolved by WP-CLI core.
+			return;
+		}
+
+		$admins = get_users( [
+			'role'    => 'administrator',
+			'number'  => 1,
+			'orderby' => 'ID',
+			'order'   => 'ASC',
+			'fields'  => 'ID',
+		] );
+
+		if ( empty( $admins ) ) {
+			WP_CLI::error( 'No administrator account found to run scos/fill-image-meta as. Pass --user=<id|login|email> explicitly.' );
+		}
+
+		$admin_id = absint( $admins[0] );
+		wp_set_current_user( $admin_id );
+
+		WP_CLI::log( sprintf(
+			'No --user supplied — running as administrator #%d (%s) to satisfy the ability permission check.',
+			$admin_id,
+			wp_get_current_user()->user_login
 		) );
 	}
 }

--- a/site-essentials/Modules/SeoMeta/Meta_Fields.php
+++ b/site-essentials/Modules/SeoMeta/Meta_Fields.php
@@ -6,6 +6,9 @@
  * @subpackage Modules\SeoMeta
  * @since      1.0.0
  * v1.2 | 2026-06-04
+ * v1.3 | 2026-07-17 — scos_seo_tldr sanitize_callback: sanitize_textarea_field →
+ *                      wp_kses_post, to match Meta_Box::save()'s own sanitizer now
+ *                      that the field supports bold/lists via wp_editor().
  */
 
 namespace SiteEssentials\Modules\SeoMeta;
@@ -32,9 +35,13 @@ class Meta_Fields {
 		$textarea = array_merge( $string, [ 'sanitize_callback' => 'sanitize_textarea_field' ] );
 		$url      = array_merge( $string, [ 'sanitize_callback' => 'esc_url_raw' ] );
 
+		// TLDR allows a small set of HTML tags (bold, lists, links) via wp_editor() —
+		// must match Meta_Box::save()'s wp_kses_post() sanitizer, not the plain-text one.
+		$tldr_field = array_merge( $string, [ 'sanitize_callback' => 'wp_kses_post' ] );
+
 		// Core SEO
 		register_post_meta( '', 'scos_seo_breadcrumb_title', $string );
-		register_post_meta( '', 'scos_seo_tldr',             $textarea );
+		register_post_meta( '', 'scos_seo_tldr',             $tldr_field );
 		register_post_meta( '', 'scos_seo_title',            $string );
 		register_post_meta( '', 'scos_seo_description',      $textarea );
 

--- a/site-essentials/Modules/SeoMeta/assets/meta-box.css
+++ b/site-essentials/Modules/SeoMeta/assets/meta-box.css
@@ -140,6 +140,16 @@
 	color: #646970;
 }
 
+/* ── TLDR rich-text editor (teeny wp_editor) ── */
+.scos-seo-tldr-editor,
+.scos-seo-tldr-editor .wp-editor-wrap,
+.scos-seo-tldr-editor .wp-editor-container {
+	width: 100%;
+}
+.scos-seo-tldr-editor .mce-toolbar-grp {
+	background: #f6f7f7;
+}
+
 /* ── Label row (TLDR label + inline button) ── */
 .scos-seo-label-row {
 	display: flex;

--- a/site-essentials/Modules/SeoMeta/assets/scos-seo-suggest.js
+++ b/site-essentials/Modules/SeoMeta/assets/scos-seo-suggest.js
@@ -19,6 +19,8 @@
  *     → pick-to-fill sets #scos_seo_tldr
  *
  * v1.0 | 2026-06-24
+ * v1.1 | 2026-07-17 — fillField() now syncs via the TinyMCE API when the target is
+ *                      a wp_editor() instance (scos_seo_tldr switched from textarea).
  */
 
 ( function () {
@@ -77,6 +79,17 @@
 	// -------------------------------------------------------------------------
 
 	function fillField( id, value ) {
+		// scos_seo_tldr is a TinyMCE (wp_editor teeny) instance — its visible content
+		// lives in the TinyMCE iframe, not the underlying textarea's .value, so it
+		// needs to be set (and marked dirty/saved) through the TinyMCE API instead.
+		var editor = window.tinymce && window.tinymce.get ? window.tinymce.get( id ) : null;
+		if ( editor && ! editor.isHidden() ) {
+			editor.setContent( value );
+			editor.save(); // sync back to the underlying textarea before submit
+			editor.fire( 'change' );
+			return;
+		}
+
 		var el = document.getElementById( id );
 		if ( ! el ) return;
 		el.value = value;

--- a/site-essentials/Modules/SeoMeta/views/meta-box.php
+++ b/site-essentials/Modules/SeoMeta/views/meta-box.php
@@ -17,6 +17,10 @@
  *   $global_freeze_date        bool   — site-wide freeze option
  *
  * @package SiteEssentials
+ *
+ * v1.0 | 2026-06-24
+ * v1.1 | 2026-07-17 — TLDR field switched from plain textarea to a teeny
+ *                      wp_editor() instance (bold/lists/link, no images).
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -76,9 +80,31 @@ defined( 'ABSPATH' ) || exit;
 				</button>
 				<?php endif; ?>
 			</label>
-			<textarea name="scos_seo_tldr" id="scos_seo_tldr" rows="3"
-				placeholder="<?php esc_attr_e( 'Brief 1–3 sentence summary used for voice search, social sharing, and the [tldr] shortcode…', 'site-essentials' ); ?>"><?php echo esc_textarea( $tldr ); ?></textarea>
-			<p class="scos-seo-help"><?php esc_html_e( 'Shown via [tldr] shortcode. Also used for Google Speakable.', 'site-essentials' ); ?></p>
+			<div class="scos-seo-tldr-editor">
+				<?php
+				wp_editor(
+					$tldr,
+					'scos_seo_tldr',
+					[
+						'textarea_name'    => 'scos_seo_tldr',
+						'textarea_rows'    => 4,
+						'teeny'            => true,
+						'media_buttons'    => false,
+						'drag_drop_upload' => false,
+						'quicktags'        => false,
+						'tinymce'          => [
+							'toolbar1'          => 'bold,italic,bullist,numlist,link,unlink,undo,redo',
+							'toolbar2'          => '',
+							'statusbar'         => false,
+							'resize'            => false,
+							'wpautop'           => true,
+							'menubar'           => false,
+						],
+					]
+				);
+				?>
+			</div>
+			<p class="scos-seo-help"><?php esc_html_e( 'Bold and lists are supported (no images). Shown via [tldr] shortcode. Also used for Google Speakable.', 'site-essentials' ); ?></p>
 		</div>
 
 		<!-- Meta Title -->


### PR DESCRIPTION
- wp scos fill-image-meta failed with a permission error because WP-CLI runs as user 0 by default, and the ability's permission_callback requires upload_files. The command now falls back to the site's first admin when no --user is passed.
- scos_seo_tldr switches from a plain textarea to a teeny wp_editor() instance (bold, lists, links, no images), so it can be used for short-form formatted summaries. Sanitize callback aligned to wp_kses_post to match the metabox's own save handler. Downstream plain-text consumers (Airtable sync, social amplification prompts, content inventory export) now strip tags before use.