### PR TITLE
Fix login redirects double-prefixing admin_url() and locking editors …

### DIFF
--- a/brighter-core/includes/bw-admin-tweaks.php
+++ b/brighter-core/includes/bw-admin-tweaks.php
@@ -5,9 +5,12 @@
  * File: custom-admin.php
  * Purpose: Enhancements and modifications to the WordPress admin UI.
  *
- * Version: 4.1.0
+ * Version: 4.1.1 | 2026-07-30
  *
  * Changelog:
+ * 4.1.1 - FIXED: login_redirect double-prefixed absolute URLs with admin_url(), causing
+ *         /wp-admin/https:/site/wp-admin/ 404s. Editors now fall back to the dashboard
+ *         instead of the Support hub when no redirect is configured.
  * 4.1.0 - CLEANED: Removed optimization status (moved to bw-content-strategy.php)
  * 4.0.0 - Initial version
  *
@@ -85,7 +88,35 @@ add_action('wp_footer', function() {
 });
 
 /**
- * Redirect all users to Brighter Support page on login
+ * Resolve a stored se_agency_login_redirect_* value to a safe absolute URL.
+ *
+ * Stored values are absolute URLs (the Access tab uses <input type="url">), but
+ * older or hand-edited values may be root-relative ("/wp-admin/edit.php") or
+ * admin-relative ("admin.php?page=foo"). Only the admin-relative form needs
+ * admin_url() prefixing — prefixing an already-absolute URL produced the
+ * https://site/wp-admin/https://site/wp-admin/ 404. Off-site targets are
+ * rejected by wp_validate_redirect() and fall through to $fallback.
+ *
+ * @param string $url      Raw option value.
+ * @param string $fallback Absolute URL used when $url is empty or off-site.
+ * @return string
+ */
+function bw_resolve_login_redirect( $url, $fallback ) {
+    $url = trim( (string) $url );
+
+    if ( '' === $url ) {
+        return $fallback;
+    }
+
+    $is_complete = (bool) preg_match( '#^(https?:)?//#i', $url ) || '/' === $url[0];
+    $candidate   = $is_complete ? $url : admin_url( $url );
+    $validated   = wp_validate_redirect( $candidate, '' );
+
+    return '' !== $validated ? $validated : $fallback;
+}
+
+/**
+ * Redirect users to their configured landing page on login
  * Compatible with WPGhost redirect override
  */
 // SCOS-SUPPORT-PASS2 — login redirect wired to Agency Access tab options
@@ -100,22 +131,20 @@ function bw_redirect_to_support_page( $redirect_to, $request, $user ) {
     set_transient( 'bw_backup_reminder_' . $user->ID, true, 60 );
 
     // SCOS-SUPPORT-PASS2 — removed hardcoded redirect, now controlled via Agency > Access tab
-    $fallback = admin_url( 'admin.php?page=site-essentials-support' ); // SCOS-SUPPORT-PASS2 — updated fallback from brighter_support to site-essentials-support
-    $roles    = (array) $user->roles;
+    $support   = admin_url( 'admin.php?page=site-essentials-support' ); // SCOS-SUPPORT-PASS2 — updated fallback from brighter_support to site-essentials-support
+    $dashboard = admin_url();
+    $roles     = (array) $user->roles;
 
     if ( in_array( 'administrator', $roles, true ) ) { // SCOS-SUPPORT-PASS2 — administrator redirect
-        $url = get_option( 'se_agency_login_redirect_admin', '' );
-        return $url ? admin_url( ltrim( $url, '/' ) ) : $fallback;
+        return bw_resolve_login_redirect( get_option( 'se_agency_login_redirect_admin', '' ), $support );
     }
 
     if ( in_array( 'shop_manager', $roles, true ) ) { // SCOS-SUPPORT-PASS2 — shop_manager redirect
-        $url = get_option( 'se_agency_login_redirect_shop_manager', '' );
-        return $url ? admin_url( ltrim( $url, '/' ) ) : $fallback;
+        return bw_resolve_login_redirect( get_option( 'se_agency_login_redirect_shop_manager', '' ), $support );
     }
 
     if ( in_array( 'editor', $roles, true ) ) { // SCOS-SUPPORT-PASS2 — editor redirect
-        $url = get_option( 'se_agency_login_redirect_editor', '' );
-        return $url ? admin_url( ltrim( $url, '/' ) ) : $fallback;
+        return bw_resolve_login_redirect( get_option( 'se_agency_login_redirect_editor', '' ), $dashboard );
     }
 
     return $redirect_to;

--- a/site-essentials/Core/Admin_UI.php
+++ b/site-essentials/Core/Admin_UI.php
@@ -7,9 +7,13 @@
  *
  * @package    SiteEssentials
  * @subpackage Core
- * @version    1.1.0
+ * @version    1.1.1
  * @since      1.0.0
  *
+ * v1.1.1 | 2026-07-30 — Support hub menu registered for editor/shop_manager (was
+ *                      manage_options only, which blocked admin.php before the
+ *                      render callback's role check). Access tab login redirects
+ *                      validated through scos_agency_sanitize_login_redirect().
  * v1.1 | 2026-07-21 — Remove Make.com webhook save handling from save_sma_settings()
  *                      (deprecated, unused on all sites).
  */
@@ -55,6 +59,14 @@ class Admin_UI {
     const SUPPORT_PAGE_SLUG     = 'site-essentials-support';
     const AGENCY_PAGE_SLUG      = 'site-essentials-agency';
     const AGENTIC_PAGE_SLUG     = 'site-essentials-agentic';
+
+    /**
+     * Roles allowed to view the read-only Support hub.
+     *
+     * @since 1.1.1
+     * @var   string[]
+     */
+    const SUPPORT_PAGE_ROLES = [ 'administrator', 'editor', 'shop_manager' ];
 
     /** Legacy Support → Schema (bw-schema-admin); removed from brighter-core — redirect here. */
     private const LEGACY_BRIGHTER_SCHEMA_PAGE = 'brighter-schema';
@@ -235,11 +247,14 @@ class Admin_UI {
             30                                                   // Position
         );
 
-        // Top-level Support shell — highest priority, near top of admin menu
+        // Top-level Support shell — highest priority, near top of admin menu.
+        // Registered per-role: admin.php refuses to load a page the current user's
+        // capability can't reach, so gating on manage_options here locked editors and
+        // shop managers out before render_support_page() ever ran.
         add_menu_page(
             __( 'Support', 'site-essentials' ),
             __( 'Support', 'site-essentials' ),
-            'manage_options',
+            self::current_user_can_view_support() ? 'read' : 'do_not_allow',
             self::SUPPORT_PAGE_SLUG,
             [ $this, 'render_support_page' ],
             'dashicons-sos',
@@ -565,14 +580,23 @@ class Admin_UI {
      */
     public function render_support_page() {
         // SCOS-SUPPORT-PASS2 — multi-role support page access
-        $allowed_roles = [ 'administrator', 'editor', 'shop_manager' ];
-        $user          = wp_get_current_user();
-        $has_access    = (bool) array_intersect( $allowed_roles, (array) $user->roles );
-        if ( ! $has_access ) {
+        if ( ! self::current_user_can_view_support() ) {
             wp_die( esc_html__( 'Insufficient permissions.', 'site-essentials' ) );
         }
 
         include SITE_ESSENTIALS_PATH . 'Views/support-page.php';
+    }
+
+    /**
+     * Whether the current user holds a role allowed to view the Support hub.
+     *
+     * @since 1.1.1
+     * @return bool
+     */
+    public static function current_user_can_view_support() {
+        $user = wp_get_current_user();
+
+        return (bool) array_intersect( self::SUPPORT_PAGE_ROLES, (array) $user->roles );
     }
 
     /**
@@ -627,12 +651,20 @@ class Admin_UI {
             }
 
             if ( 'access' === $post_tab ) {
-                $redir_admin        = isset( $_POST['se_agency_login_redirect_admin'] ) ? esc_url_raw( wp_unslash( $_POST['se_agency_login_redirect_admin'] ) ) : '';
-                $redir_editor       = isset( $_POST['se_agency_login_redirect_editor'] ) ? esc_url_raw( wp_unslash( $_POST['se_agency_login_redirect_editor'] ) ) : '';
-                $redir_shop_manager = isset( $_POST['se_agency_login_redirect_shop_manager'] ) ? esc_url_raw( wp_unslash( $_POST['se_agency_login_redirect_shop_manager'] ) ) : ''; // SCOS-SUPPORT-PASS2 — shop_manager redirect field added
-                update_option( 'se_agency_login_redirect_admin', $redir_admin );
-                update_option( 'se_agency_login_redirect_editor', $redir_editor );
-                update_option( 'se_agency_login_redirect_shop_manager', $redir_shop_manager ); // SCOS-SUPPORT-PASS2 — shop_manager redirect field added
+                // SCOS-SUPPORT-PASS2 — shop_manager redirect field added
+                $redirect_keys = [
+                    'se_agency_login_redirect_admin',
+                    'se_agency_login_redirect_editor',
+                    'se_agency_login_redirect_shop_manager',
+                ];
+                foreach ( $redirect_keys as $key ) {
+                    $value = isset( $_POST[ $key ] ) ? esc_url_raw( wp_unslash( $_POST[ $key ] ) ) : '';
+                    // Rejects off-site targets, so an empty value always means "use the role default".
+                    if ( function_exists( 'scos_agency_sanitize_login_redirect' ) ) {
+                        $value = scos_agency_sanitize_login_redirect( $value );
+                    }
+                    update_option( $key, $value );
+                }
             }
 
             wp_safe_redirect(

--- a/site-essentials/Views/agency-page.php
+++ b/site-essentials/Views/agency-page.php
@@ -3,6 +3,10 @@
  * Agency white label settings page (se_agency_* options).
  *
  * @package SiteEssentials
+ * @version 1.1
+ *
+ * v1.1 | 2026-07-30 — Access tab login redirect fields show role defaults as
+ *                     placeholders instead of pre-filled values.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -555,10 +559,17 @@ $page_url = admin_url( 'admin.php' );
 
 		<?php elseif ( 'access' === $active_tab ) : ?>
 
+			<?php
+			// Leaving a field empty falls back to these, so show them as placeholders
+			// rather than pre-filled values — a pre-filled default is indistinguishable
+			// from a saved choice and gets persisted on the next save.
+			$support_default   = admin_url( 'admin.php?page=site-essentials-support' );
+			$dashboard_default = admin_url();
+			?>
 			<div class="scos-card">
 				<div class="scos-card__header">
 					<h2 class="scos-card__title"><?php esc_html_e( 'Login redirects', 'site-essentials' ); ?></h2>
-					<p class="scos-card__desc"><?php esc_html_e( 'Where users land after logging in.', 'site-essentials' ); ?></p>
+					<p class="scos-card__desc"><?php esc_html_e( 'Where users land after logging in. Must be a URL on this site — off-site URLs are discarded.', 'site-essentials' ); ?></p>
 				</div>
 				<div class="scos-card__body">
 					<table class="scos-form">
@@ -570,7 +581,9 @@ $page_url = admin_url( 'admin.php' );
 								</th>
 								<td>
 									<input type="url" id="se_agency_login_redirect_admin" name="se_agency_login_redirect_admin" class="scos-input"
-										value="<?php echo esc_url( get_option( 'se_agency_login_redirect_admin', admin_url( 'admin.php?page=site-essentials-support' ) ) ); ?>" />
+										value="<?php echo esc_url( get_option( 'se_agency_login_redirect_admin', '' ) ); ?>"
+										placeholder="<?php echo esc_attr( $support_default ); ?>" />
+									<p class="description"><?php esc_html_e( 'Leave empty to use the Support hub.', 'site-essentials' ); ?></p>
 								</td>
 							</tr>
 							<tr>
@@ -580,7 +593,9 @@ $page_url = admin_url( 'admin.php' );
 								</th>
 								<td>
 									<input type="url" id="se_agency_login_redirect_editor" name="se_agency_login_redirect_editor" class="scos-input"
-										value="<?php echo esc_url( get_option( 'se_agency_login_redirect_editor', admin_url( 'admin.php?page=site-essentials-support' ) ) ); ?>" />
+										value="<?php echo esc_url( get_option( 'se_agency_login_redirect_editor', '' ) ); ?>"
+										placeholder="<?php echo esc_attr( $dashboard_default ); ?>" />
+									<p class="description"><?php esc_html_e( 'Leave empty to use the standard WordPress dashboard.', 'site-essentials' ); ?></p>
 								</td>
 							</tr>
 							<tr> <?php // SCOS-SUPPORT-PASS2 — shop_manager redirect field added ?>
@@ -590,8 +605,9 @@ $page_url = admin_url( 'admin.php' );
 								</th>
 								<td>
 									<input type="url" id="se_agency_login_redirect_shop_manager" name="se_agency_login_redirect_shop_manager" class="scos-input"
-										value="<?php echo esc_url( get_option( 'se_agency_login_redirect_shop_manager', admin_url( 'admin.php?page=site-essentials-support' ) ) ); ?>"
-										placeholder="<?php echo esc_attr( admin_url( 'admin.php?page=site-essentials-support' ) ); ?>" />
+										value="<?php echo esc_url( get_option( 'se_agency_login_redirect_shop_manager', '' ) ); ?>"
+										placeholder="<?php echo esc_attr( $support_default ); ?>" />
+									<p class="description"><?php esc_html_e( 'Leave empty to use the Support hub.', 'site-essentials' ); ?></p>
 								</td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
…out of Support

The Access tab stores absolute URLs (input type=url, validated by scos_agency_sanitize_login_redirect), but bw_redirect_to_support_page() wrapped every stored value in admin_url() again, so any configured redirect produced /wp-admin/https://site/wp-admin/ and 404'd. Values are now only admin_url() prefixed when genuinely admin-relative, and run through wp_validate_redirect() so off-site targets fall back instead of becoming an open redirect.

Editors with no configured redirect now land on the standard dashboard rather than the Support hub. The Support hub itself was registered with manage_options even though render_support_page() allowed editor and shop_manager, so admin.php rejected the request before the role check ran; it is now registered per-role via Admin_UI::current_user_can_view_support().

Also route all three Access tab redirect keys through the shared sanitizer (shop_manager was skipping it), and show role defaults as placeholders instead of pre-filled values so an unsaved default is no longer indistinguishable from a deliberate choice.