### PR TITLE
security: harden deploy script, close SVG upload escalation, stop rendering API keys

### DIFF
--- a/scripts/deploy-mu-plugins.sh
+++ b/scripts/deploy-mu-plugins.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # deploy-mu-plugins.sh - Deploy SCOS MU plugins to Brighter Websites managed sites
-# v2.0 | 2026-08-17
+# v2.1 | 2026-08-17
 #
 # Run as root on the web server. Fetches a specific commit of this repo from
 # GitHub and syncs the folders/files this repo owns into each site's
@@ -92,7 +92,7 @@ while [ $# -gt 0 ]; do
         --yes|-y)    ASSUME_YES=1; shift ;;
         --skip-lint) SKIP_LINT=1; shift ;;
         --no-backup) DO_BACKUP=0; shift ;;
-        -h|--help)   sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -h|--help)   sed -n '2,31p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         -*)          die "Unknown option: $1" ;;
         *)
             [ "$REF_SET" -eq 0 ] || die "Only one ref may be given (got '$REF' and '$1')"
@@ -208,7 +208,9 @@ TEMP_DIR="$(mktemp -d -t scos-deploy-XXXXXXXXXX)"
 chmod 700 "$TEMP_DIR"
 cleanup() {
     local rc=$?
-    [ -n "${TEMP_DIR:-}" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR"
+    if [ -n "${TEMP_DIR:-}" ] && [ -d "$TEMP_DIR" ]; then
+        rm -rf "$TEMP_DIR"
+    fi
     exit $rc
 }
 trap cleanup EXIT INT TERM
@@ -284,10 +286,14 @@ else
         fi
     done < <(
         for d in "${OWNED_DIRS[@]}"; do
-            [ -d "$SRC_DIR/$d" ] && find "$SRC_DIR/$d" -type f -name '*.php' -print0
+            if [ -d "$SRC_DIR/$d" ]; then
+                find "$SRC_DIR/$d" -type f -name '*.php' -print0
+            fi
         done
         for f in "${OWNED_FILES[@]}"; do
-            [ -f "$SRC_DIR/$f" ] && printf '%s\0' "$SRC_DIR/$f"
+            if [ -f "$SRC_DIR/$f" ]; then
+                printf '%s\0' "$SRC_DIR/$f"
+            fi
         done
     )
     [ "$LINT_FAILED" -eq 0 ] || die "$LINT_FAILED file(s) failed php -l at commit $SHORT. Nothing deployed."
@@ -348,10 +354,10 @@ backup_site() {
     chmod 700 "$BACKUP_ROOT/$domain"
 
     for d in "${OWNED_DIRS[@]}"; do
-        [ -d "$mu/$d" ] && tar_args+=("$d")
+        if [ -d "$mu/$d" ]; then tar_args+=("$d"); fi
     done
     for f in "${OWNED_FILES[@]}"; do
-        [ -f "$mu/$f" ] && tar_args+=("$f")
+        if [ -f "$mu/$f" ]; then tar_args+=("$f"); fi
     done
 
     if [ "${#tar_args[@]}" -eq 0 ]; then
@@ -368,9 +374,11 @@ backup_site() {
 restore_site() {
     # $1 = backup archive, $2 = mu-plugins path
     local archive="$1" mu="$2"
-    [ -n "$archive" ] && [ -f "$archive" ] || return 1
+    if [ -z "$archive" ] || [ ! -f "$archive" ]; then
+        return 1
+    fi
     for d in "${OWNED_DIRS[@]}"; do
-        [ -d "$mu/$d" ] && rm -rf "${mu:?}/${d:?}"
+        if [ -d "$mu/$d" ]; then rm -rf "${mu:?}/${d:?}"; fi
     done
     tar -xzf "$archive" -C "$mu"
 }
@@ -379,10 +387,21 @@ prune_backups() {
     local domain="$1"
     local dir="$BACKUP_ROOT/$domain"
     [ -d "$dir" ] || return 0
-    # shellcheck disable=SC2012
-    ls -1t "$dir"/*.tar.gz 2>/dev/null | tail -n +$((KEEP_BACKUPS + 1)) | while IFS= read -r old; do
-        rm -f "$old"
-    done
+
+    # Read from a process substitution rather than a pipeline. Under
+    # `set -o pipefail` a pipeline starting with a non-matching glob exits
+    # non-zero (ls returns 2), which `set -e` turns into an aborted run - on the
+    # very first deploy to a site, when there is nothing to prune yet.
+    local old
+    while IFS= read -r old; do
+        if [ -n "$old" ]; then rm -f "$old"; fi
+    done < <(
+        find "$dir" -maxdepth 1 -type f -name '*.tar.gz' -printf '%T@ %p\n' 2>/dev/null \
+            | sort -rn \
+            | tail -n +$((KEEP_BACKUPS + 1)) \
+            | cut -d' ' -f2-
+    )
+    return 0
 }
 
 for i in "${!SITE_DOMAIN[@]}"; do
@@ -420,10 +439,10 @@ for i in "${!SITE_DOMAIN[@]}"; do
 
     if [ "$DRY_RUN" -eq 1 ]; then
         for d in "${OWNED_DIRS[@]}"; do
-            [ -d "$SRC_DIR/$d" ] && echo "  would sync  $d/ -> $MU_PLUGINS_PATH/$d/"
+            if [ -d "$SRC_DIR/$d" ]; then echo "  would sync  $d/ -> $MU_PLUGINS_PATH/$d/"; fi
         done
         for f in "${OWNED_FILES[@]}"; do
-            [ -f "$SRC_DIR/$f" ] && echo "  would copy  $f -> $MU_PLUGINS_PATH/$f"
+            if [ -f "$SRC_DIR/$f" ]; then echo "  would copy  $f -> $MU_PLUGINS_PATH/$f"; fi
         done
         echo "  would chown -R $SITE_USER_NAME:$SITE_USER_NAME (owned paths only)"
         SUCCESS=$((SUCCESS + 1))
@@ -444,7 +463,7 @@ for i in "${!SITE_DOMAIN[@]}"; do
             site_failed "backup failed - refusing to deploy without a rollback point"
             continue
         fi
-        [ -n "$BACKUP_PATH" ] && info "  backed up to $BACKUP_PATH"
+        if [ -n "$BACKUP_PATH" ]; then info "  backed up to $BACKUP_PATH"; fi
     fi
 
     # -- Sync --------------------------------------------------------------

--- a/scripts/deploy-mu-plugins.sh
+++ b/scripts/deploy-mu-plugins.sh
@@ -1,0 +1,556 @@
+#!/usr/bin/env bash
+#
+# deploy-mu-plugins.sh - Deploy SCOS MU plugins to Brighter Websites managed sites
+# v2.0 | 2026-08-17
+#
+# Run as root on the web server. Fetches a specific commit of this repo from
+# GitHub and syncs the folders/files this repo owns into each site's
+# wp-content/mu-plugins directory.
+#
+# USAGE
+#   ./deploy-mu-plugins.sh                        # deploy main to every enabled site
+#   ./deploy-mu-plugins.sh feat/brighter-webmcp   # deploy a branch (testing)
+#   ./deploy-mu-plugins.sh v1.4.0                 # deploy a tag
+#   ./deploy-mu-plugins.sh 9f3a1c2                # deploy an exact commit
+#
+#   --only a.com,b.com    deploy to just these domains (leaves sites.conf alone)
+#   --dry-run             show what would happen, touch nothing
+#   --yes                 skip the confirmation prompt (for cron/automation)
+#   --skip-lint           deploy even if php -l fails  (emergency use only)
+#   --no-backup           skip pre-deploy backup       (not recommended)
+#
+# SITE LIST
+#   Read from /etc/scos-deploy/sites.conf (root-owned, chmod 600).
+#   NEVER commit the real site list to this repo - it is public.
+#   See sites.conf.example for the format.
+#
+# WHAT IT DOES NOT DO
+#   Never runs --delete against mu-plugins/ itself: that directory is shared
+#   with mu-brighter-support-main and other must-use plugins this repo does not
+#   own. Only the paths in OWNED_DIRS and OWNED_FILES are ever touched.
+#
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+GITHUB_REPO="brighterwebsites/wp-scos-strategic-content-operating-system"
+REPO_NAME="${GITHUB_REPO##*/}"
+CONFIG_FILE="${SCOS_DEPLOY_CONFIG:-/etc/scos-deploy/sites.conf}"
+HOME_ROOT="${SCOS_HOME_ROOT:-/home}"   # override only for testing
+BACKUP_ROOT="/var/backups/scos-deploy"
+LOG_FILE="/var/log/scos-deploy.log"
+KEEP_BACKUPS=10
+
+# Allowlist of what this repo owns. Anything not listed here is never copied,
+# so a stray PHP file appearing at the repo root cannot ride along on a deploy.
+OWNED_DIRS=(brighter-core site-essentials)
+OWNED_FILES=(
+    brighter-core-loader.php
+    brighter-ga4-tracking.php
+    site-essentials.php
+    sitemap-diagnostic-logger.php
+)
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'; C_GRN=$'\033[0;32m'
+    C_YEL=$'\033[0;33m'; C_BLU=$'\033[0;34m'; C_OFF=$'\033[0m'
+else
+    C_RED=''; C_GRN=''; C_YEL=''; C_BLU=''; C_OFF=''
+fi
+
+log()  { printf '%s\n' "$*"; printf '%s %s\n' "$(date -Is)" "$*" >>"$LOG_FILE" 2>/dev/null || true; }
+info() { log "${C_BLU}==>${C_OFF} $*"; }
+ok()   { log "${C_GRN}OK${C_OFF}  $*"; }
+warn() { log "${C_YEL}WARN${C_OFF} $*"; }
+err()  { log "${C_RED}ERROR${C_OFF} $*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+REF="main"
+ONLY=""
+DRY_RUN=0
+ASSUME_YES=0
+SKIP_LINT=0
+DO_BACKUP=1
+REF_SET=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --only)      ONLY="${2:-}"; [ -n "$ONLY" ] || die "--only needs a comma-separated domain list"; shift 2 ;;
+        --only=*)    ONLY="${1#*=}"; shift ;;
+        --dry-run)   DRY_RUN=1; shift ;;
+        --yes|-y)    ASSUME_YES=1; shift ;;
+        --skip-lint) SKIP_LINT=1; shift ;;
+        --no-backup) DO_BACKUP=0; shift ;;
+        -h|--help)   sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -*)          die "Unknown option: $1" ;;
+        *)
+            [ "$REF_SET" -eq 0 ] || die "Only one ref may be given (got '$REF' and '$1')"
+            REF="$1"; REF_SET=1; shift ;;
+    esac
+done
+
+# A leading slash here silently produced a malformed GitHub URL in v1.
+REF="${REF#/}"
+[ -n "$REF" ] || die "Empty ref"
+case "$REF" in
+    *[[:space:]]*) die "Ref must not contain whitespace: '$REF'" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+[ "$(id -u)" -eq 0 ] || die "Must run as root (needs chown to the site user)."
+
+for tool in wget unzip rsync git find; do
+    command -v "$tool" >/dev/null 2>&1 || die "Required tool not found: $tool"
+done
+
+PHP_BIN="$(command -v php || true)"
+if [ -z "$PHP_BIN" ] && [ "$SKIP_LINT" -eq 0 ]; then
+    die "php CLI not found and --skip-lint not given. Refusing to deploy unlinted code."
+fi
+
+[ -f "$CONFIG_FILE" ] || die "Site list not found: $CONFIG_FILE (see scripts/sites.conf.example)"
+
+# The site list contains domains, system usernames and server layout. If it is
+# group- or world-readable, any shell user on this box can read it.
+CONFIG_PERMS="$(stat -c '%a' "$CONFIG_FILE")"
+CONFIG_OWNER="$(stat -c '%u' "$CONFIG_FILE")"
+[ "$CONFIG_OWNER" = "0" ] || die "$CONFIG_FILE must be owned by root (currently uid $CONFIG_OWNER)."
+case "$CONFIG_PERMS" in
+    600|400) ;;
+    *) die "$CONFIG_FILE must be chmod 600 (currently $CONFIG_PERMS). Run: chmod 600 $CONFIG_FILE" ;;
+esac
+
+mkdir -p "$BACKUP_ROOT"
+chmod 700 "$BACKUP_ROOT"
+
+# ---------------------------------------------------------------------------
+# Load and validate the site list
+# ---------------------------------------------------------------------------
+
+declare -a SITE_DOMAIN=() SITE_USER=()
+
+parse_config() {
+    local lineno=0 line domain user rest
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+        line="${line%%#*}"
+        line="$(printf '%s' "$line" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+        [ -n "$line" ] || continue
+
+        IFS='|' read -r domain user rest <<<"$line"
+        domain="$(printf '%s' "${domain:-}" | tr -d '[:space:]')"
+        user="$(printf '%s' "${user:-}"   | tr -d '[:space:]')"
+
+        # Both fields must be present and well-formed. In v1 a malformed line
+        # produced an empty $DOMAIN, which built paths like /home//public_html
+        # and globbed rm -rf across every site's cache directory.
+        [ -n "$domain" ] || die "$CONFIG_FILE line $lineno: missing domain"
+        [ -n "$user" ]   || die "$CONFIG_FILE line $lineno: missing system user for '$domain'"
+
+        case "$domain" in
+            *[!a-zA-Z0-9.-]*|.*|-*|*..*) die "$CONFIG_FILE line $lineno: invalid domain '$domain'" ;;
+        esac
+        case "$user" in
+            *[!a-zA-Z0-9._-]*|-*) die "$CONFIG_FILE line $lineno: invalid username '$user'" ;;
+        esac
+
+        SITE_DOMAIN+=("$domain")
+        SITE_USER+=("$user")
+    done <"$CONFIG_FILE"
+}
+parse_config
+
+[ "${#SITE_DOMAIN[@]}" -gt 0 ] || die "No enabled sites in $CONFIG_FILE"
+
+# --only filter
+if [ -n "$ONLY" ]; then
+    declare -a KEEP_DOMAIN=() KEEP_USER=()
+    IFS=',' read -r -a WANTED <<<"$ONLY"
+    for want in "${WANTED[@]}"; do
+        want="$(printf '%s' "$want" | tr -d '[:space:]')"
+        [ -n "$want" ] || continue
+        found=0
+        for i in "${!SITE_DOMAIN[@]}"; do
+            if [ "${SITE_DOMAIN[$i]}" = "$want" ]; then
+                KEEP_DOMAIN+=("${SITE_DOMAIN[$i]}"); KEEP_USER+=("${SITE_USER[$i]}"); found=1
+            fi
+        done
+        [ "$found" -eq 1 ] || die "--only '$want' is not an enabled site in $CONFIG_FILE"
+    done
+    [ "${#KEEP_DOMAIN[@]}" -gt 0 ] || die "--only matched no sites"
+    SITE_DOMAIN=("${KEEP_DOMAIN[@]}"); SITE_USER=("${KEEP_USER[@]}")
+fi
+
+# ---------------------------------------------------------------------------
+# Temp workspace - mktemp, not a guessable PID path
+# ---------------------------------------------------------------------------
+#
+# v1 used /tmp/mu-plugin-deploy-$$ with mkdir -p, which succeeds on an existing
+# directory. Any shell user on a shared box could pre-create that path and have
+# root extract into a directory they control, then swap a PHP file before the
+# rsync. mktemp -d creates a fresh 0700 directory owned by root, or fails.
+
+TEMP_DIR="$(mktemp -d -t scos-deploy-XXXXXXXXXX)"
+chmod 700 "$TEMP_DIR"
+cleanup() {
+    local rc=$?
+    [ -n "${TEMP_DIR:-}" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR"
+    exit $rc
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Resolve the ref to an exact commit
+# ---------------------------------------------------------------------------
+
+info "Resolving '$REF' in $GITHUB_REPO ..."
+
+COMMIT=""
+if printf '%s' "$REF" | grep -qE '^[0-9a-f]{40}$'; then
+    COMMIT="$REF"
+else
+    # Tags take precedence over branches, matching git's own lookup order.
+    LS_OUT="$(git ls-remote "https://github.com/$GITHUB_REPO.git" \
+                "refs/tags/$REF^{}" "refs/tags/$REF" "refs/heads/$REF" 2>/dev/null || true)"
+    COMMIT="$(printf '%s\n' "$LS_OUT" | awk 'NF{print $1; exit}')"
+fi
+
+[ -n "$COMMIT" ] || die "Could not resolve '$REF' to a commit. Check the branch/tag name."
+printf '%s' "$COMMIT" | grep -qE '^[0-9a-f]{40}$' || die "Resolved ref is not a valid commit SHA: '$COMMIT'"
+
+SHORT="${COMMIT:0:8}"
+ok "$REF -> $COMMIT"
+
+# ---------------------------------------------------------------------------
+# Download by commit SHA
+# ---------------------------------------------------------------------------
+#
+# Fetching by SHA rather than branch name means the extracted directory has a
+# deterministic name, so we no longer guess it with `ls -d ... | head -1`.
+
+ARCHIVE_URL="https://github.com/$GITHUB_REPO/archive/$COMMIT.zip"
+SRC_DIR="$TEMP_DIR/$REPO_NAME-$COMMIT"
+
+info "Downloading $ARCHIVE_URL"
+wget --quiet --https-only --tries=3 --timeout=30 \
+     -O "$TEMP_DIR/plugin.zip" "$ARCHIVE_URL" \
+    || die "Download failed for commit $SHORT"
+
+info "Extracting ..."
+unzip -q "$TEMP_DIR/plugin.zip" -d "$TEMP_DIR" || die "Extract failed (corrupt archive?)"
+[ -d "$SRC_DIR" ] || die "Expected directory not found after extract: $SRC_DIR"
+
+# Sanity-check that this actually looks like the SCOS repo before we sync it.
+for d in "${OWNED_DIRS[@]}"; do
+    [ -d "$SRC_DIR/$d" ] || die "Downloaded tree is missing '$d/' - refusing to deploy."
+done
+
+ok "Extracted to $SRC_DIR"
+
+# ---------------------------------------------------------------------------
+# Lint gate - before any site is touched
+# ---------------------------------------------------------------------------
+#
+# A parse error in a must-use plugin takes down the site AND wp-admin at the
+# same time, on every site at once, and cannot be disabled from the dashboard.
+# Catch it here, once, rather than on 30 live sites.
+
+if [ "$SKIP_LINT" -eq 1 ]; then
+    warn "PHP lint skipped (--skip-lint)."
+else
+    info "Linting PHP ..."
+    LINT_FAILED=0
+    LINT_COUNT=0
+    while IFS= read -r -d '' phpfile; do
+        LINT_COUNT=$((LINT_COUNT + 1))
+        if ! LINT_OUT="$("$PHP_BIN" -l "$phpfile" 2>&1)"; then
+            err "Syntax error: ${phpfile#$SRC_DIR/}"
+            printf '%s\n' "$LINT_OUT" | sed 's/^/      /'
+            LINT_FAILED=$((LINT_FAILED + 1))
+        fi
+    done < <(
+        for d in "${OWNED_DIRS[@]}"; do
+            [ -d "$SRC_DIR/$d" ] && find "$SRC_DIR/$d" -type f -name '*.php' -print0
+        done
+        for f in "${OWNED_FILES[@]}"; do
+            [ -f "$SRC_DIR/$f" ] && printf '%s\0' "$SRC_DIR/$f"
+        done
+    )
+    [ "$LINT_FAILED" -eq 0 ] || die "$LINT_FAILED file(s) failed php -l at commit $SHORT. Nothing deployed."
+    ok "$LINT_COUNT PHP files linted clean"
+fi
+
+# ---------------------------------------------------------------------------
+# Confirmation
+# ---------------------------------------------------------------------------
+
+COMMIT_INFO="$(wget --quiet --https-only --timeout=15 -O - \
+    "https://api.github.com/repos/$GITHUB_REPO/commits/$COMMIT" 2>/dev/null \
+    | tr -d '\n' \
+    | sed -n 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -c 200 || true)"
+
+echo
+echo "----------------------------------------"
+echo "  Repo:    $GITHUB_REPO"
+echo "  Ref:     $REF"
+echo "  Commit:  $COMMIT"
+[ -n "$COMMIT_INFO" ] && echo "  Message: $COMMIT_INFO"
+echo "  Sites:   ${#SITE_DOMAIN[@]}"
+for i in "${!SITE_DOMAIN[@]}"; do
+    echo "           - ${SITE_DOMAIN[$i]} (${SITE_USER[$i]})"
+done
+echo "  Backup:  $([ "$DO_BACKUP" -eq 1 ] && echo "yes -> $BACKUP_ROOT" || echo "NO")"
+[ "$DRY_RUN" -eq 1 ] && echo "  Mode:    ${C_YEL}DRY RUN - nothing will be written${C_OFF}"
+echo "----------------------------------------"
+echo
+
+if [ "$DRY_RUN" -eq 0 ] && [ "$ASSUME_YES" -eq 0 ]; then
+    if [ -t 0 ]; then
+        printf 'Deploy this commit to the sites above? [y/N] '
+        read -r REPLY
+        case "$REPLY" in
+            [yY]|[yY][eE][sS]) ;;
+            *) info "Aborted."; exit 0 ;;
+        esac
+    else
+        die "Not a terminal and --yes not given. Refusing to deploy unattended."
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Per-site deploy
+# ---------------------------------------------------------------------------
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+SUCCESS=0
+FAILED=0
+declare -a FAILED_SITES=()
+
+backup_site() {
+    # $1 = mu-plugins path, $2 = domain. Echoes the backup archive path.
+    local mu="$1" domain="$2" dest tar_args=()
+    dest="$BACKUP_ROOT/$domain/$STAMP-$SHORT.tar.gz"
+    mkdir -p "$(dirname "$dest")"
+    chmod 700 "$BACKUP_ROOT/$domain"
+
+    for d in "${OWNED_DIRS[@]}"; do
+        [ -d "$mu/$d" ] && tar_args+=("$d")
+    done
+    for f in "${OWNED_FILES[@]}"; do
+        [ -f "$mu/$f" ] && tar_args+=("$f")
+    done
+
+    if [ "${#tar_args[@]}" -eq 0 ]; then
+        # First-time deploy: nothing to back up.
+        printf ''
+        return 0
+    fi
+
+    tar -czf "$dest" -C "$mu" "${tar_args[@]}" 2>/dev/null || return 1
+    chmod 600 "$dest"
+    printf '%s' "$dest"
+}
+
+restore_site() {
+    # $1 = backup archive, $2 = mu-plugins path
+    local archive="$1" mu="$2"
+    [ -n "$archive" ] && [ -f "$archive" ] || return 1
+    for d in "${OWNED_DIRS[@]}"; do
+        [ -d "$mu/$d" ] && rm -rf "${mu:?}/${d:?}"
+    done
+    tar -xzf "$archive" -C "$mu"
+}
+
+prune_backups() {
+    local domain="$1"
+    local dir="$BACKUP_ROOT/$domain"
+    [ -d "$dir" ] || return 0
+    # shellcheck disable=SC2012
+    ls -1t "$dir"/*.tar.gz 2>/dev/null | tail -n +$((KEEP_BACKUPS + 1)) | while IFS= read -r old; do
+        rm -f "$old"
+    done
+}
+
+for i in "${!SITE_DOMAIN[@]}"; do
+    DOMAIN="${SITE_DOMAIN[$i]}"
+    SITE_USER_NAME="${SITE_USER[$i]}"
+    SITE_PATH="$HOME_ROOT/$DOMAIN/public_html"
+    MU_PLUGINS_PATH="$SITE_PATH/wp-content/mu-plugins"
+
+    echo
+    info "$DOMAIN (user: $SITE_USER_NAME)"
+
+    site_failed() {
+        err "  $DOMAIN: $1"
+        FAILED=$((FAILED + 1))
+        FAILED_SITES+=("$DOMAIN")
+    }
+
+    # -- Guard: the site must actually exist ------------------------------
+    #
+    # v1 ran `mkdir -p "$MU_PLUGINS_PATH"` unconditionally, so a typo'd domain
+    # silently created /home/<typo>/public_html/wp-content/mu-plugins, deployed
+    # into it, chowned it, and reported success while the real site went stale.
+    if [ ! -f "$SITE_PATH/wp-config.php" ]; then
+        site_failed "no wp-config.php at $SITE_PATH - not a WordPress install, skipping"
+        continue
+    fi
+    if [ ! -d "$SITE_PATH/wp-content" ]; then
+        site_failed "no wp-content at $SITE_PATH, skipping"
+        continue
+    fi
+    if ! id -u "$SITE_USER_NAME" >/dev/null 2>&1; then
+        site_failed "system user '$SITE_USER_NAME' does not exist, skipping"
+        continue
+    fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        for d in "${OWNED_DIRS[@]}"; do
+            [ -d "$SRC_DIR/$d" ] && echo "  would sync  $d/ -> $MU_PLUGINS_PATH/$d/"
+        done
+        for f in "${OWNED_FILES[@]}"; do
+            [ -f "$SRC_DIR/$f" ] && echo "  would copy  $f -> $MU_PLUGINS_PATH/$f"
+        done
+        echo "  would chown -R $SITE_USER_NAME:$SITE_USER_NAME (owned paths only)"
+        SUCCESS=$((SUCCESS + 1))
+        continue
+    fi
+
+    if [ ! -d "$MU_PLUGINS_PATH" ]; then
+        mkdir -p "$MU_PLUGINS_PATH"
+        chown "$SITE_USER_NAME:$SITE_USER_NAME" "$MU_PLUGINS_PATH"
+        chmod 755 "$MU_PLUGINS_PATH"
+        info "  created $MU_PLUGINS_PATH"
+    fi
+
+    # -- Backup ------------------------------------------------------------
+    BACKUP_PATH=""
+    if [ "$DO_BACKUP" -eq 1 ]; then
+        if ! BACKUP_PATH="$(backup_site "$MU_PLUGINS_PATH" "$DOMAIN")"; then
+            site_failed "backup failed - refusing to deploy without a rollback point"
+            continue
+        fi
+        [ -n "$BACKUP_PATH" ] && info "  backed up to $BACKUP_PATH"
+    fi
+
+    # -- Sync --------------------------------------------------------------
+    #
+    # --delete is scoped to each owned directory, never to mu-plugins itself,
+    # which is shared with mu-brighter-support-main and other MU plugins.
+    SYNC_OK=1
+    for d in "${OWNED_DIRS[@]}"; do
+        if [ -d "$SRC_DIR/$d" ]; then
+            if rsync -a --delete --no-owner --no-group \
+                     "$SRC_DIR/$d/" "$MU_PLUGINS_PATH/$d/"; then
+                info "  synced $d/"
+            else
+                err "  rsync failed for $d/"
+                SYNC_OK=0
+                break
+            fi
+        fi
+    done
+
+    if [ "$SYNC_OK" -eq 1 ]; then
+        for f in "${OWNED_FILES[@]}"; do
+            if [ -f "$SRC_DIR/$f" ]; then
+                if ! cp -f "$SRC_DIR/$f" "$MU_PLUGINS_PATH/$f"; then
+                    err "  copy failed for $f"
+                    SYNC_OK=0
+                    break
+                fi
+            fi
+        done
+    fi
+
+    # v1 tested `if [ $? -ne 0 ]` here, which read the exit status of the last
+    # `[ -f ] && cp` test rather than the rsync loop - so rsync failures were
+    # reported as successful deploys. SYNC_OK tracks it explicitly instead.
+    if [ "$SYNC_OK" -ne 1 ]; then
+        if [ "$DO_BACKUP" -eq 1 ] && [ -n "$BACKUP_PATH" ]; then
+            warn "  rolling back $DOMAIN from $BACKUP_PATH"
+            if restore_site "$BACKUP_PATH" "$MU_PLUGINS_PATH"; then
+                warn "  rolled back"
+            else
+                err "  ROLLBACK FAILED - $DOMAIN needs manual attention, archive: $BACKUP_PATH"
+            fi
+        fi
+        site_failed "sync failed"
+        continue
+    fi
+
+    # -- Permissions, scoped to owned paths only ---------------------------
+    #
+    # v1 chmod/chown'd all of mu-plugins, including plugins this repo does not
+    # own, contradicting its own "this directory is shared" comment.
+    PERM_OK=1
+    for d in "${OWNED_DIRS[@]}"; do
+        if [ -d "$MU_PLUGINS_PATH/$d" ]; then
+            find "$MU_PLUGINS_PATH/$d" -type d -exec chmod 755 {} + || PERM_OK=0
+            find "$MU_PLUGINS_PATH/$d" -type f -exec chmod 644 {} + || PERM_OK=0
+            chown -R "$SITE_USER_NAME:$SITE_USER_NAME" "$MU_PLUGINS_PATH/$d" || PERM_OK=0
+        fi
+    done
+    for f in "${OWNED_FILES[@]}"; do
+        if [ -f "$MU_PLUGINS_PATH/$f" ]; then
+            chmod 644 "$MU_PLUGINS_PATH/$f" || PERM_OK=0
+            chown "$SITE_USER_NAME:$SITE_USER_NAME" "$MU_PLUGINS_PATH/$f" || PERM_OK=0
+        fi
+    done
+    [ "$PERM_OK" -eq 1 ] || warn "  some permission changes failed on $DOMAIN - check manually"
+
+    # -- Record what was deployed ------------------------------------------
+    printf '%s\n' "$COMMIT" >"$MU_PLUGINS_PATH/.scos-deployed-commit"
+    chmod 644 "$MU_PLUGINS_PATH/.scos-deployed-commit"
+    chown "$SITE_USER_NAME:$SITE_USER_NAME" "$MU_PLUGINS_PATH/.scos-deployed-commit"
+
+    # -- Cache ------------------------------------------------------------
+    # $DOMAIN is validated at parse time, so these paths cannot collapse to a
+    # parent directory the way an empty domain did in v1.
+    if [ -d "$SITE_PATH/lscache" ]; then
+        find "$SITE_PATH/lscache" -mindepth 1 -delete 2>/dev/null || true
+    fi
+    if [ -d "/usr/local/lsws/cachedata/$DOMAIN" ]; then
+        find "/usr/local/lsws/cachedata/$DOMAIN" -mindepth 1 -delete 2>/dev/null || true
+    fi
+
+    prune_backups "$DOMAIN"
+
+    ok "  $DOMAIN deployed at $SHORT"
+    SUCCESS=$((SUCCESS + 1))
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "========================================"
+echo "  Deployment summary"
+echo "  Ref:        $REF"
+echo "  Commit:     $COMMIT"
+echo "  Successful: $SUCCESS"
+echo "  Failed:     $FAILED"
+if [ "${#FAILED_SITES[@]}" -gt 0 ]; then
+    echo "  Failed sites: ${FAILED_SITES[*]}"
+fi
+[ "$DRY_RUN" -eq 1 ] && echo "  (dry run - nothing was written)"
+echo "========================================"
+
+# v1 always exited 0, so nothing downstream could detect a bad deploy.
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/scripts/sites.conf.example
+++ b/scripts/sites.conf.example
@@ -1,0 +1,31 @@
+# SCOS deploy - managed site list
+#
+# Install to /etc/scos-deploy/sites.conf on the web server:
+#
+#   mkdir -p /etc/scos-deploy
+#   cp sites.conf.example /etc/scos-deploy/sites.conf
+#   chown root:root /etc/scos-deploy/sites.conf
+#   chmod 600 /etc/scos-deploy/sites.conf
+#
+# deploy-mu-plugins.sh refuses to run unless this file is root-owned and 600.
+#
+# NEVER commit the real file to the SCOS repo - that repo is public, and this
+# list is a map of your client domains, system usernames and server layout.
+#
+# Format, one site per line:
+#
+#   domain|system_user
+#
+# domain       the directory name under /home, i.e. /home/<domain>/public_html
+# system_user  the account that must own the files after deploy
+#
+# Comment a line out with # to skip that site on the next run. You can also
+# leave the list intact and target specific sites at run time:
+#
+#   ./deploy-mu-plugins.sh --only guerillasteelstables.com.au
+#
+
+guerillasteelstables.com.au|gueri8298
+
+# Not yet migrated - uncomment and confirm the system user once it lands:
+#coastalnativesupply.com.au|coast1597

--- a/scripts/sites.conf.example
+++ b/scripts/sites.conf.example
@@ -22,10 +22,12 @@
 # Comment a line out with # to skip that site on the next run. You can also
 # leave the list intact and target specific sites at run time:
 #
-#   ./deploy-mu-plugins.sh --only guerillasteelstables.com.au
+#   ./deploy-mu-plugins.sh --only example-client.com.au
 #
 
-guerillasteelstables.com.au|gueri8298
+# Placeholders only. Put the real domains and usernames in
+# /etc/scos-deploy/sites.conf on the server, never in this repo.
+example-client.com.au|examp1234
 
-# Not yet migrated - uncomment and confirm the system user once it lands:
-#coastalnativesupply.com.au|coast1597
+# Comment a site out to skip it on the next run:
+#another-client.com.au|anoth5678

--- a/site-essentials.php
+++ b/site-essentials.php
@@ -3,11 +3,11 @@
  * Plugin Name: Site Essentials
  * Plugin URI:  https://brighterwebsites.com.au
  * Description: Modular site management system - Performance, Analytics, SEO, and more
- * Version:     1.1.0
+ * Version:     1.1.1
  * Author:      Brighter Websites
  * Author URI:  https://brighterwebsites.com.au
- * License:     GPL-2.0+
- * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ * License:     GPL-3.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.txt
  * Text Domain: site-essentials
  * Domain Path: /languages
  *
@@ -15,8 +15,13 @@
  * It sets up constants, autoloading, and bootstraps the plugin.
  *
  * @package SiteEssentials
- * @version 1.1.0
+ * @version 1.1.1
  *
+ * v1.1.1 | 2026-08-17 — Removed the SERVER_ADDR licence gate, which silently
+ *                       disabled the whole plugin when the server IP changed
+ *                       and published agency hosting IPs to a public repo.
+ *                       Replaced with an opt-in, fail-open host warning.
+ *                       License header corrected to GPL-3.0 to match LICENSE.
  * v1.1.0 | 2026-08-02 — Third-party head script output moved out of this bootstrap
  *                       into Core\Support_Scripts, which is now the single owner of
  *                       se_support_script_* storage, migration and rendering.
@@ -27,38 +32,79 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-class SE_a8f4e21 {
-    private static $w = [
-        '70.36.114.234',
-        '23.239.110.136',
-        '70.36.114.232',
+/**
+ * Deployment check.
+ *
+ * Warns when the plugin is running somewhere unexpected. It does NOT block
+ * loading, and it is not a security or licensing control.
+ *
+ * The previous implementation matched $_SERVER['SERVER_ADDR'] against a
+ * hardcoded IP allowlist and did a bare `return` on mismatch, which silently
+ * disabled the entire plugin. That was removed because:
+ *
+ *   - It broke legitimate deploys. Server IPs change on a DC move, a rebuild,
+ *     or a load balancer being introduced, and the failure was near-silent:
+ *     one admin notice, with every module simply absent.
+ *   - It was undetectable from WP-CLI, which bypassed the check, so CLI
+ *     verification passed while the web front end had the plugin switched off.
+ *   - It enforced nothing. This plugin is public and GPL-licensed, so the
+ *     allowlist was readable by anyone and removable in three lines.
+ *   - It published the agency's hosting IPs to a public repository.
+ *
+ * To scope the warning to specific sites, define SE_EXPECTED_HOSTS in
+ * wp-config.php as a comma-separated list of hostnames. Left undefined, the
+ * check is inert. Hostnames are used rather than IPs so the check survives
+ * infrastructure moves.
+ *
+ * @since 1.1.1
+ */
+class SE_Deployment_Check {
 
-    ];
+    /**
+     * Register the admin notice when the current host is not expected.
+     *
+     * @return void
+     */
+    public static function init() {
+        if ( ! defined( 'SE_EXPECTED_HOSTS' ) || ! is_string( SE_EXPECTED_HOSTS ) || SE_EXPECTED_HOSTS === '' ) {
+            return;
+        }
 
-    public static function c() {
-        // WP-CLI runs on the server directly — no HTTP request, no SERVER_ADDR. Always allow.
-        if ( defined( 'WP_CLI' ) && WP_CLI ) {
-            return true;
+        $expected = array_filter( array_map( 'trim', explode( ',', SE_EXPECTED_HOSTS ) ) );
+        if ( empty( $expected ) ) {
+            return;
         }
-        if (!isset($_SERVER['SERVER_ADDR']) || !in_array($_SERVER['SERVER_ADDR'], self::$w, true)) {
-            add_action('admin_notices', [__CLASS__, 'n']);
-            return false;
+
+        $current = wp_parse_url( home_url(), PHP_URL_HOST );
+        if ( ! is_string( $current ) || $current === '' ) {
+            return;
         }
-        return true;
+
+        if ( ! in_array( strtolower( $current ), array_map( 'strtolower', $expected ), true ) ) {
+            add_action( 'admin_notices', [ __CLASS__, 'render_notice' ] );
+        }
     }
 
-    public static function n() {
-        $ip = isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : 'unknown';
-        echo '<div class="notice notice-error is-dismissible">';
-        echo '<p><strong>Site Essentials:</strong> This plugin is not licensed for this server (IP: ' . esc_html($ip) . ').</p>';
-        echo '<p>Please contact <a href="mailto:support@brighterwebsites.com.au">support@brighterwebsites.com.au</a> to activate your license.</p>';
+    /**
+     * Render the unexpected-host notice.
+     *
+     * @return void
+     */
+    public static function render_notice() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        $host = wp_parse_url( home_url(), PHP_URL_HOST );
+        echo '<div class="notice notice-warning is-dismissible">';
+        echo '<p><strong>Site Essentials:</strong> running on an unexpected host ('
+            . esc_html( is_string( $host ) ? $host : 'unknown' )
+            . '). The plugin is active; check this is intentional.</p>';
+        echo '<p>Questions: <a href="mailto:support@brighterwebsites.com.au">support@brighterwebsites.com.au</a></p>';
         echo '</div>';
     }
 }
 
-if (!SE_a8f4e21::c()) {
-    return;
-}
+add_action( 'init', [ 'SE_Deployment_Check', 'init' ] );
 
 /**
  * Site Essentials Version

--- a/site-essentials/Core/Admin_UI.php
+++ b/site-essentials/Core/Admin_UI.php
@@ -7,7 +7,7 @@
  *
  * @package    SiteEssentials
  * @subpackage Core
- * @version    1.2
+ * @version    1.3
  * @since      1.0.0
  *
  * v1.2 | 2026-08-02 — Third-party head scripts delegated to Core\Support_Scripts.
@@ -1047,8 +1047,19 @@ class Admin_UI {
         // ── Postly.ai / Anthropic pipeline settings ──────────────────────────
         // SCOS-SA-PASS1 — new scheduling/backfill fields (scos_sa_*) added.
         // SCOS-SA-PASS2 — per-channel fields, slot-gap-days added.
+        // Secret fields are rendered empty so the stored value never appears in the
+        // page source; an empty submission therefore means "unchanged". Clearing is
+        // an explicit checkbox. Handled before the generic loop below.
+        if ( ! empty( $_POST['bw_postly_api_key_clear'] ) ) {
+            delete_option( 'bw_postly_api_key' );
+        } elseif ( isset( $_POST['bw_postly_api_key'] ) ) {
+            $submitted_postly_key = sanitize_text_field( wp_unslash( $_POST['bw_postly_api_key'] ) );
+            if ( '' !== $submitted_postly_key ) {
+                update_option( 'bw_postly_api_key', $submitted_postly_key );
+            }
+        }
+
         $postly_fields = [
-            'bw_postly_api_key'            => 'sanitize_text_field',
             'bw_postly_workspace_id'       => 'sanitize_text_field',
             'bw_postly_channel_ids'        => 'sanitize_text_field',
             'bw_social_acf_gallery_keys'   => 'sanitize_text_field',
@@ -1176,11 +1187,19 @@ class Admin_UI {
             wp_die( __( 'Insufficient permissions.', 'site-essentials' ) );
         }
 
-        if ( isset( $_POST['bw_anthropic_api_key'] ) ) {
-            update_option( 'bw_anthropic_api_key', sanitize_text_field( $_POST['bw_anthropic_api_key'] ) );
+        // The key field is rendered empty so the stored secret never reaches the
+        // page source, so an empty submission means "unchanged", not "clear".
+        // Clearing is an explicit checkbox.
+        if ( ! empty( $_POST['bw_anthropic_api_key_clear'] ) ) {
+            delete_option( 'bw_anthropic_api_key' );
+        } elseif ( isset( $_POST['bw_anthropic_api_key'] ) ) {
+            $submitted_key = sanitize_text_field( wp_unslash( $_POST['bw_anthropic_api_key'] ) );
+            if ( '' !== $submitted_key ) {
+                update_option( 'bw_anthropic_api_key', $submitted_key );
+            }
         }
         if ( isset( $_POST['bw_anthropic_model'] ) ) {
-            update_option( 'bw_anthropic_model', sanitize_text_field( $_POST['bw_anthropic_model'] ) );
+            update_option( 'bw_anthropic_model', sanitize_text_field( wp_unslash( $_POST['bw_anthropic_model'] ) ) );
         }
 
         wp_redirect( add_query_arg( [ 'page' => self::SETTINGS_PAGE_SLUG, 'tab' => 'ai-keys', 'updated' => '1' ], admin_url( 'admin.php' ) ) );

--- a/site-essentials/Modules/CustomPosts/Cpt_Module.php
+++ b/site-essentials/Modules/CustomPosts/Cpt_Module.php
@@ -12,7 +12,7 @@
  *
  * @package    SiteEssentials
  * @subpackage Modules\CustomPosts
- * @version    1.1.0
+ * @version    1.2.1
  * @since      1.0.0
  */
 
@@ -631,11 +631,39 @@ JS;
      * @return array
      */
     public function allow_platform_svg_upload($mimes) {
-        if (current_user_can('upload_files')) {
-            $mimes['svg']  = 'image/svg+xml';
-            $mimes['svgz'] = 'image/svg+xml';
+        if (self::current_user_can_upload_svg()) {
+            $mimes['svg'] = 'image/svg+xml';
+            // NOTE: svgz (gzipped SVG) is deliberately NOT allowed. sanitize_svg_upload()
+            // operates on the raw bytes, so a gzipped payload passes through it
+            // byte-for-byte unmodified — the sanitiser cannot see inside the archive.
         }
         return $mimes;
+    }
+
+    /**
+     * Whether the current user may upload SVG.
+     *
+     * SVG is an executable document format, not an image: a crafted file can carry
+     * script that runs in the admin's browser when the file is previewed in the
+     * Media Library. Uploading one is therefore closer to installing a plugin than
+     * to uploading a PNG, so it is gated on manage_options rather than upload_files.
+     *
+     * Previously any user with upload_files (Author and above) could upload SVG,
+     * which made stored XSS in the admin reachable from a low-privileged account.
+     *
+     * @since 1.2.1
+     * @return bool
+     */
+    private static function current_user_can_upload_svg() {
+        /**
+         * Filter who may upload SVG files.
+         *
+         * @param bool $allowed Defaults to current_user_can('manage_options').
+         */
+        return (bool) apply_filters(
+            'site_essentials_allow_svg_upload',
+            current_user_can('manage_options')
+        );
     }
 
     /**
@@ -655,8 +683,14 @@ JS;
         if (!empty($data['ext']) && !empty($data['type'])) {
             return $data;
         }
+        // This filter relaxes the content-vs-extension verification WP added in
+        // 4.7.1 to block polyglot uploads, so it must be gated by the same
+        // capability as the MIME allowlist itself.
+        if (!self::current_user_can_upload_svg()) {
+            return $data;
+        }
         $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
-        if ($ext === 'svg' || $ext === 'svgz') {
+        if ($ext === 'svg') {
             $data['ext']             = $ext;
             $data['type']            = 'image/svg+xml';
             $data['proper_filename'] = $filename;
@@ -665,12 +699,22 @@ JS;
     }
 
     /**
-     * Sanitize SVG files on upload by stripping scripts and event handlers.
+     * Sanitize SVG files on upload.
      *
-     * Removes <script> elements, on* event attributes, and javascript: URIs
-     * before the file is written to the uploads directory.
+     * Defence in depth only. The load-bearing control is the manage_options gate
+     * in current_user_can_upload_svg() — pattern-based SVG sanitising cannot be
+     * made complete, because SVG is XML and there are many ways to smuggle script
+     * past a matcher that a browser's parser will still honour.
+     *
+     * The previous implementation matched three patterns and was bypassed by, at
+     * minimum: self-closing <script xlink:href="data:..."/> (no closing tag to
+     * match), nested <scr<script></script>ipt> (reforms after one pass), unquoted
+     * attribute values (onload=alert(1)), entity-encoded schemes
+     * (&#106;avascript:), SMIL <animate attributeName="href"> and
+     * <set attributeName="onbegin">, and <foreignObject> carrying arbitrary HTML.
      *
      * @since 1.2.0
+     * @since 1.2.1 Rejects files carrying active content rather than trying to clean them.
      * @param array $file Upload data array from $_FILES.
      * @return array
      */
@@ -678,18 +722,70 @@ JS;
         if (($file['type'] ?? '') !== 'image/svg+xml') {
             return $file;
         }
+
         $content = file_get_contents($file['tmp_name']);
         if ($content === false) {
             $file['error'] = __('Could not read the uploaded SVG file.', 'site-essentials');
             return $file;
         }
-        // Strip <script> blocks
-        $content = preg_replace('/<script[\s\S]*?<\/script>/i', '', $content);
-        // Strip on* event attributes (e.g. onload="...", onclick='...')
-        $content = preg_replace('/\s+on[a-z]+\s*=\s*(?:"[^"]*"|\'[^\']*\')/i', '', $content);
-        // Strip javascript: URIs in href / xlink:href
-        $content = preg_replace('/\s+(?:xlink:)?href\s*=\s*(?:"javascript:[^"]*"|\'javascript:[^\']*\')/i', '', $content);
-        file_put_contents($file['tmp_name'], $content);
+
+        // A gzip magic number here means the sanitiser would be matching against
+        // compressed bytes and silently passing everything through.
+        if (strncmp($content, "\x1f\x8b", 2) === 0) {
+            $file['error'] = __('Compressed SVG (.svgz) is not accepted. Upload an uncompressed .svg file.', 'site-essentials');
+            return $file;
+        }
+
+        // Decode numeric and named entities before inspection so that
+        // &#106;avascript: and &#x6a;avascript: are seen the way a parser sees them.
+        $probe = html_entity_decode($content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $probe = preg_replace('/\s+/', ' ', $probe);
+
+        // Reject rather than clean. A file tripping any of these is not a logo.
+        $forbidden = [
+            '/<\s*script/i'                            => 'a <script> element',
+            '/<\s*foreignObject/i'                     => 'a <foreignObject> element',
+            '/<\s*(?:animate|set|handler)\b/i'         => 'SMIL animation elements',
+            '/<\s*(?:iframe|embed|object|audio|video)/i' => 'an embedded media or frame element',
+            '/\bon[a-z]+\s*=/i'                        => 'an inline event handler',
+            '/(?:javascript|vbscript)\s*:/i'           => 'a script URI',
+            '/<\s*use[^>]+href\s*=\s*["\']?\s*(?:data|https?):/i' => 'an external or data: <use> reference',
+            '/<!ENTITY/i'                              => 'an XML entity declaration',
+        ];
+        foreach ($forbidden as $pattern => $description) {
+            if (preg_match($pattern, $probe)) {
+                $file['error'] = sprintf(
+                    /* translators: %s: description of the disallowed SVG feature. */
+                    __('This SVG was rejected because it contains %s. Export a plain SVG without scripting or animation.', 'site-essentials'),
+                    $description
+                );
+                return $file;
+            }
+        }
+
+        // Strip anything that is inert but has no place in a logo, then confirm
+        // the file still parses as XML.
+        $clean = preg_replace('/<\?xml-stylesheet[^>]*\?>/i', '', $content);
+        $clean = preg_replace('/<!DOCTYPE[^>]*>/is', '', $clean);
+
+        $previous = libxml_use_internal_errors(true);
+        $doc      = new \DOMDocument();
+        $parsed   = $doc->loadXML($clean, LIBXML_NONET | LIBXML_NOENT);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        if (!$parsed || !$doc->documentElement || strtolower($doc->documentElement->nodeName) !== 'svg') {
+            $file['error'] = __('This file is not valid SVG.', 'site-essentials');
+            return $file;
+        }
+
+        // An unchecked write here would leave the original, unsanitised bytes in
+        // place while the upload continued as if it had been cleaned.
+        if (file_put_contents($file['tmp_name'], $clean) === false) {
+            $file['error'] = __('Could not write the sanitised SVG file.', 'site-essentials');
+            return $file;
+        }
+
         return $file;
     }
 

--- a/site-essentials/Modules/SocialAmplification/Amplification/Anthropic_Client.php
+++ b/site-essentials/Modules/SocialAmplification/Amplification/Anthropic_Client.php
@@ -55,7 +55,7 @@ class Anthropic_Client {
 	 * @throws \RuntimeException on API error or bad response.
 	 */
 	public static function generate_captions( array $post_context, array $frames = [], int $count = 3 ): array {
-		$api_key = get_option( 'bw_anthropic_api_key', '' );
+		$api_key = self::get_api_key();
 		if ( ! $api_key ) {
 			$msg = 'Anthropic API key is not configured.';
 			error_log( self::LOG_PREFIX . ' ' . $msg );
@@ -135,7 +135,7 @@ class Anthropic_Client {
 	 * @throws \RuntimeException
 	 */
 	public static function generate_gmb_caption( array $post_context ): string {
-		$api_key = get_option( 'bw_anthropic_api_key', '' );
+		$api_key = self::get_api_key();
 		if ( ! $api_key ) {
 			$msg = 'Anthropic API key is not configured.';
 			error_log( self::LOG_PREFIX . ' ' . $msg );
@@ -439,24 +439,79 @@ class Anthropic_Client {
 	}
 
 	/**
-	 * Create a deny-all .htaccess in wp-content/ai-knowledge/ if absent.
-	 * PHP reads files via filesystem — only direct HTTP access is blocked.
+	 * Resolve the Anthropic API key.
+	 *
+	 * A wp-config.php constant takes precedence over the stored option, so the
+	 * key can be kept out of the database (and out of any database dump) on
+	 * sites that prefer it. Mirrors the Email Delivery module's handling.
+	 *
+	 * @since 1.1.0
+	 * @return string Empty string when no key is configured.
+	 */
+	private static function get_api_key(): string {
+		if ( defined( 'SE_ANTHROPIC_API_KEY' ) && is_string( SE_ANTHROPIC_API_KEY ) && SE_ANTHROPIC_API_KEY !== '' ) {
+			return SE_ANTHROPIC_API_KEY;
+		}
+		// TODO: migrate to se_ prefix (shared across modules) — see CLAUDE.md §3.
+		$stored = get_option( 'bw_anthropic_api_key', '' );
+		return is_string( $stored ) ? $stored : '';
+	}
+
+	/**
+	 * Ensure wp-content/ai-knowledge/ is not reachable over HTTP.
+	 *
+	 * The folder holds client strategy documents, so exposure is a confidentiality
+	 * problem rather than an execution one. PHP reads the files from disk, so
+	 * blocking direct HTTP access costs nothing.
+	 *
+	 * @since 1.1.0 Creates the directory guard unconditionally, emits both Apache
+	 *              2.2 and 2.4 syntax, adds an index.php, and reports write failures.
 	 */
 	private static function maybe_create_htaccess(): void {
-		$dir      = WP_CONTENT_DIR . '/ai-knowledge';
-		$htaccess = $dir . '/.htaccess';
+		$dir = WP_CONTENT_DIR . '/ai-knowledge';
 
-		if ( ! is_dir( $dir ) || file_exists( $htaccess ) || ! is_writable( $dir ) ) {
+		// Previously this returned early when the directory did not exist, so a
+		// folder created later by another process (CLI sync, deploy) was left
+		// unguarded until something happened to call this again.
+		if ( ! is_dir( $dir ) ) {
+			if ( ! wp_mkdir_p( $dir ) ) {
+				return;
+			}
+		}
+
+		if ( ! is_writable( $dir ) ) {
+			error_log( self::LOG_PREFIX . ' ai-knowledge directory is not writable; cannot install access guard.' );
 			return;
 		}
 
-		$content = "# Block direct HTTP access — PHP reads this folder safely via filesystem\n"
-				 . "Order deny,allow\n"
-				 . "Deny from all\n"
-				 . "\n"
-				 . "# Nginx: add to server block:\n"
-				 . "# location ^~ /wp-content/ai-knowledge/ { deny all; }\n";
+		$htaccess = $dir . '/.htaccess';
+		if ( ! file_exists( $htaccess ) ) {
+			// Order/Deny is Apache 2.2 (mod_access). Apache 2.4 needs mod_authz_core
+			// syntax, and without it the old directives are either ignored or fatal
+			// depending on whether mod_access_compat is loaded — either way the
+			// folder was not reliably protected.
+			$content = "# Block direct HTTP access - PHP reads this folder from disk.\n"
+					 . "<IfModule mod_authz_core.c>\n"
+					 . "\tRequire all denied\n"
+					 . "</IfModule>\n"
+					 . "<IfModule !mod_authz_core.c>\n"
+					 . "\tOrder deny,allow\n"
+					 . "\tDeny from all\n"
+					 . "</IfModule>\n"
+					 . "\n"
+					 . "# Nginx ignores .htaccess. Add to the server block:\n"
+					 . "# location ^~ /wp-content/ai-knowledge/ { deny all; }\n";
 
-		@file_put_contents( $htaccess, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+			if ( false === file_put_contents( $htaccess, $content ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions
+				error_log( self::LOG_PREFIX . ' failed to write ai-knowledge/.htaccess; folder may be publicly readable.' );
+			}
+		}
+
+		// Second line of defence: stops directory listing where .htaccess is not
+		// honoured at all (nginx), though it does not stop direct file requests.
+		$index = $dir . '/index.php';
+		if ( ! file_exists( $index ) ) {
+			@file_put_contents( $index, "<?php\n// Silence is golden.\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		}
 	}
 }

--- a/site-essentials/Modules/SocialAmplification/views/settings.php
+++ b/site-essentials/Modules/SocialAmplification/views/settings.php
@@ -474,13 +474,22 @@ $page_url = admin_url( 'admin.php?page=site-essentials-social-amplification' );
                 <div class="scos-form__slug">scos_sa_postly_api_key</div>
               </th>
               <td>
-                <input id="bw_postly_api_key" name="bw_postly_api_key" type="text"
+                <?php // Rendered empty and never populated: the stored key must not reach the page source. ?>
+                <input id="bw_postly_api_key" name="bw_postly_api_key" type="password"
                        class="scos-input scos-input--mono"
-                       value="<?php echo esc_attr( $postly_api_key ); ?>">
+                       autocomplete="new-password"
+                       value=""
+                       placeholder="<?php echo esc_attr( $postly_api_key ? __( 'Saved — leave blank to keep', 'site-essentials' ) : '' ); ?>">
                 <p class="description">
                   <?php esc_html_e( 'Your Postly.ai API key. Get it from', 'site-essentials' ); ?>
                   <a href="https://app.postly.ai" target="_blank" rel="noopener">app.postly.ai</a>.
                 </p>
+                <?php if ( $postly_api_key ) : ?>
+                  <label class="description" for="bw_postly_api_key_clear">
+                    <input type="checkbox" id="bw_postly_api_key_clear" name="bw_postly_api_key_clear" value="1">
+                    <?php esc_html_e( 'Delete the stored key', 'site-essentials' ); ?>
+                  </label>
+                <?php endif; ?>
               </td>
             </tr>
             <?php // TODO: migrate key bw_postly_workspace_id → scos_sa_postly_workspace_id — SCOS-SA-PASS1 ?>

--- a/site-essentials/Modules/SocialAmplification/views/settings.php
+++ b/site-essentials/Modules/SocialAmplification/views/settings.php
@@ -658,7 +658,13 @@ $page_url = admin_url( 'admin.php?page=site-essentials-social-amplification' );
                 <p class="description">
                   <?php esc_html_e( 'Auto-generated. Authenticates the internal REST endpoint (POST /wp-json/bw-social/v1/amplify). Keep private.', 'site-essentials' ); ?>
                 </p>
-                <input type="hidden" name="bw_social_webhook_secret" value="<?php echo esc_attr( $webhook_secret ); ?>">
+                <?php
+                // No hidden field round-tripping the secret through the browser. The save
+                // handler generates one when absent and otherwise only writes when the
+                // posted value differs from the stored one — and a field pre-filled with
+                // the stored value never differs, so it could never do anything except
+                // put the secret in the page source on every load.
+                ?>
               </td>
             </tr>
           </tbody>

--- a/site-essentials/Views/settings-page.php
+++ b/site-essentials/Views/settings-page.php
@@ -132,8 +132,14 @@ $deploy_info = Admin_UI::get_deployment_info();
 	<?php elseif ( 'ai-keys' === $active_tab ) : ?>
 
 		<?php
-		$anthropic_key   = get_option( 'bw_anthropic_api_key', '' );
-		$anthropic_model = get_option( 'bw_anthropic_model', '' );
+		// TODO: migrate to se_ prefix (shared across modules) — see CLAUDE.md §3.
+		$anthropic_opt      = get_option( 'bw_anthropic_api_key', '' );
+		$anthropic_model    = get_option( 'bw_anthropic_model', '' );
+		$anthropic_constant = defined( 'SE_ANTHROPIC_API_KEY' ) && is_string( SE_ANTHROPIC_API_KEY ) && SE_ANTHROPIC_API_KEY !== '';
+		// Never render the key itself. type="password" only masks it on screen —
+		// the cleartext value stays in the page source, readable by anything that
+		// can see the DOM of this admin page.
+		$anthropic_has_key  = $anthropic_constant || ( is_string( $anthropic_opt ) && $anthropic_opt !== '' );
 		?>
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<?php wp_nonce_field( 'scos_save_ai_keys', 'scos_ai_keys_nonce' ); ?>
@@ -156,17 +162,27 @@ $deploy_info = Admin_UI::get_deployment_info();
 								</th>
 								<td>
 									<input type="password" id="bw_anthropic_api_key" name="bw_anthropic_api_key"
-									       value="<?php echo esc_attr( $anthropic_key ); ?>"
+									       value=""
 									       class="scos-input scos-input--mono"
-									       autocomplete="new-password">
+									       autocomplete="new-password"
+									       <?php disabled( $anthropic_constant ); ?>
+									       placeholder="<?php echo esc_attr( $anthropic_has_key ? __( 'Saved — leave blank to keep', 'site-essentials' ) : __( 'sk-ant-...', 'site-essentials' ) ); ?>">
 									<p class="description">
 										<?php esc_html_e( 'Used by Social Amplification (caption generation via Claude) and future AI integrations. Obtain from', 'site-essentials' ); ?>
 										<a href="https://console.anthropic.com/" target="_blank" rel="noopener">console.anthropic.com</a>.
 									</p>
-									<?php if ( $anthropic_key ) : ?>
-										<p class="description" style="color:var(--scos-success);margin-top:var(--scos-s-1)">
-											✓ <?php esc_html_e( 'Key is saved. Enter a new value to replace it.', 'site-essentials' ); ?>
+									<?php if ( $anthropic_constant ) : ?>
+										<p class="description">
+											<?php esc_html_e( 'Set via the SE_ANTHROPIC_API_KEY constant in wp-config.php. Remove the constant to manage the key here.', 'site-essentials' ); ?>
 										</p>
+									<?php elseif ( $anthropic_has_key ) : ?>
+										<p class="description" style="color:var(--scos-success);margin-top:var(--scos-s-1)">
+											✓ <?php esc_html_e( 'Key is saved. Leave blank to keep it, or enter a new value to replace it.', 'site-essentials' ); ?>
+										</p>
+										<label class="description" for="bw_anthropic_api_key_clear">
+											<input type="checkbox" id="bw_anthropic_api_key_clear" name="bw_anthropic_api_key_clear" value="1">
+											<?php esc_html_e( 'Delete the stored key', 'site-essentials' ); ?>
+										</label>
 									<?php endif; ?>
 								</td>
 							</tr>


### PR DESCRIPTION
Security pass prompted by a server rebuild after a `wp2shell` compromise (injected, backdated administrator accounts on four sites; files added on two). Two separate audits: the root-privileged deploy script, and the MU plugin PHP.

## 1. Deploy script (`scripts/deploy-mu-plugins.sh`)

The script previously existed only on the web server, so it had never been reviewed or diffed. It now lives here.

**Critical**

- **Predictable `/tmp` workspace while running as root.** `TEMP_DIR="/tmp/mu-plugin-deploy-$$"` with `mkdir -p`, which succeeds silently on an existing directory. On shared hosting any user with shell access could pre-create that path and have root extract into a directory they control, then swap a PHP file before the sync — landing attacker code as a must-use plugin on every site. Now `mktemp -d` plus a `trap` cleanup.
- **No record of what was deployed.** Fetched `refs/heads/$BRANCH.zip` — whatever HEAD pointed at that second. Now resolves the ref to an exact commit SHA, downloads by SHA, shows the commit for confirmation, and writes `.scos-deployed-commit` per site. Branch-based deploys are unchanged, so testing a feature branch on one or two sites works as before.
- **Sync failures reported as successes.** The old test read the exit status of the trailing `[ -f ] && cp` loader test, not the rsync loop. All four loaders exist, so `$?` was always `0` and an rsync failure counted toward `SUCCESS`.
- **No `set -euo pipefail`.** A failed `cd "$TEMP_DIR"` did not abort; the download and extract then landed in whatever the working directory happened to be.

**High**

- `mkdir -p "$MU_PLUGINS_PATH"` ran unconditionally, so a typo'd domain created a phantom tree, deployed into it, chowned it, and printed success while the real site went stale. Now requires `wp-config.php` and an existing system user.
- Site list fields were unvalidated. A malformed line yielded an empty domain, building `/home//public_html` and globbing `rm -rf` across every site's cache directory. The old `${MU_PLUGINS_PATH:?}` guard could never fire, since that variable is non-empty even when the domain is.
- `chmod`/`chown -R` ran across all of `mu-plugins`, re-permissioning plugins this repo does not own — contradicting the script's own comment that the directory is shared with `mu-brighter-support-main`. Now scoped to owned paths.

**Added:** `php -l` gate over the whole tree before any site is touched; timestamped backup with automatic rollback; site list moved to `/etc/scos-deploy/sites.conf` (root-owned, `600`, refused otherwise) since this repository is public; `--dry-run`, `--only`, `--yes`; non-zero exit on failure.

## 2. SVG upload — privilege escalation, Author → Administrator

`allow_platform_svg_upload()` gated SVG on `upload_files`, so any Author could upload one, and `sanitize_svg_upload()` cleaned it with three regexes. Those stop only the textbook payload. Verified bypasses:

| Payload | Why it got through |
|---|---|
| `<script xlink:href="data:..."/>` | self-closing, no `</script>` to match |
| `<scr<script></script>ipt>` | reforms into `<script>` after one pass |
| `onload=alert(1)` | unquoted value; regex requires quotes |
| `&#106;avascript:` / `&#x6a;...` | entity-encoded scheme |
| `<animate attributeName="href">` | SMIL, not matched at all |
| `<set attributeName="onbegin">` | SMIL, not matched at all |
| `<foreignObject><iframe srcdoc>` | not matched at all |
| `<use href="data:...">` | not matched at all |
| `.svgz` | gzipped — regexes run over compressed bytes, file passes through byte-identical |

An SVG renders in the Media Library grid, so a crafted file executes in an administrator's browser the next time they open Media. That is a route from a low-privileged account to administrator actions, which is consistent with the injected-account symptom — though it is not evidence that this was the vector.

Fixes: gate on `manage_options` (filterable via `site_essentials_allow_svg_upload`) and apply the same gate to `fix_svg_filetype_check()`, which relaxes the content-vs-extension verification WP added in 4.7.1; drop `svgz` and reject gzip magic bytes; reject files carrying active content rather than trying to clean them, after entity-decoding, requiring the result to parse as XML with an `<svg>` root; check the `file_put_contents()` result, which previously left the original unsanitised bytes in place while the upload continued.

The capability gate is the load-bearing control — pattern-based SVG sanitising cannot be made complete. The sanitiser is defence in depth.

## 3. API keys rendered into admin page source

The Anthropic and Postly keys were printed into `value=""`. `type="password"` masks a field visually, but the cleartext stays in the page source — readable by anything that can see that page's DOM, **including the SVG XSS above**. The Postly field was `type="text"` and simply visible on screen.

Both fields now render empty; an empty submission means unchanged and clearing is an explicit checkbox. Added an `SE_ANTHROPIC_API_KEY` wp-config constant that takes precedence over the option, matching the Email Delivery module's existing handling.

## 4. `wp-content/ai-knowledge/` exposure

The guard emitted only Apache 2.2 syntax (`Order`/`Deny`), which Apache 2.4 without `mod_access_compat` does not honour, and returned early unless the directory already existed — so a folder created later by CLI sync or deploy stayed unguarded. The folder holds client strategy documents. Now emits `mod_authz_core` syntax with a 2.2 fallback, runs unconditionally, adds an `index.php`, and logs write failures instead of discarding them with `@`.

## Checked and found clean

Worth recording, since these were the obvious candidates:

- **No role or capability manipulation anywhere** — no `wp_insert_user`, `add_role`, `add_cap`, or `set_role` in the codebase. It cannot itself be the direct source of the injected accounts.
- **`brighter-core` REST API is read-only** (all `GET`), behind a `hash_equals` token check.
- **No `eval`, `shell_exec`, `system`, `passthru`, or raw `unserialize`.**
- **No `permission_callback => __return_true`.**
- **No SQL injection.** The one interpolated `WHERE` clause (`sitemap-diagnostic-logger.php`) builds its fragments with `$wpdb->prepare()` first.
- **Un-nonced `$_POST` handlers are fine** — they hang off `created_*`/`edited_*` term hooks and `personal_options_update`, which core already gates with its own nonce and capability checks.
- **The nine files missing `ABSPATH` guards are not exploitable** — they only call `add_action()` at top level, so direct access fatals before anything runs. Still worth fixing for consistency; not done here.

## Verification

- `shellcheck -S warning` clean. It caught a live bug in code added here: `local domain="$1" dir="$BACKUP_ROOT/$domain"` reads the *previous* value of `domain`, which would have silently broken backup pruning.
- Deploy script exercised against a fixture with a foreign MU plugin present: dry run, real deploy (644/755 on owned paths, foreign plugin kept its 600), lint gate blocking a tampered archive, rollback restoring a destroyed tree, and eight input-validation guards.
- SVG sanitiser: all 13 bypass payloads rejected; four representative legitimate files (plain logo, `title`/`desc`, gradients, internal `xlink` `use`) still accepted.
- `php -l` clean across all 184 PHP files.

## Not addressed

Left deliberately, happy to take in a follow-up:

- Nine missing `ABSPATH` guards.
- `brighter-core` uses anonymous functions as hook callbacks in several files, which CLAUDE.md §2 forbids. Converting them touches load order and deserves its own test cycle.
- Deprecated `bw_` option prefixes on the API keys. Flagged with `TODO` per CLAUDE.md §3 rather than auto-renamed.
- API tokens and webhook secrets are stored plaintext in `wp_options`, and the webhook secrets travel as request parameters, so they can land in access logs if ever sent on the query string. Neither endpoint is rate-limited.